### PR TITLE
Add by_type! macro, multiple catch arms, finally block

### DIFF
--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -20,9 +20,6 @@ fn main() -> duchess::GlobalResult<()> {
             .execute(jvm)?;
 
         l.throw_something()
-            .catch::<Throwable, _>(|t| t.print_stack_trace())
-            .execute(jvm)?;
-        l.throw_something()
             .catching()
             .catch::<Throwable, _>(|t| t.print_stack_trace())
             .finally(l.log_int(42))

--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -22,6 +22,11 @@ fn main() -> duchess::GlobalResult<()> {
         l.throw_something()
             .catch::<Throwable, _>(|t| t.print_stack_trace())
             .execute(jvm)?;
+        l.throw_something()
+            .catching()
+            .catch::<Throwable, _>(|t| t.print_stack_trace())
+            .finally(l.log_int(42))
+            .execute(jvm)?;
         println!("all good, though!");
 
         Ok(())

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -17,6 +17,7 @@ quote = "1.0.26"
 regex = "1"
 rust-format = { version = "0.3.4", features = ["token_stream"] }
 str_inflector = "0.12.0"
+once_cell = "1.17.1"
 
 [dev-dependencies]
 expect-test = "1.4.1"

--- a/src/catch.rs
+++ b/src/catch.rs
@@ -5,7 +5,9 @@ use jni::{
     JNIEnv,
 };
 
-use crate::{cast::Upcast, error::Error, java::lang::Throwable, JvmOp, Local};
+use crate::{
+    cast::Upcast, error::Error, java::lang::Throwable, jvm::CloneIn, IntoVoid, Jvm, JvmOp, Local,
+};
 
 /// Plumbing utility to check the exception state of the JVM thread convert it into a [`crate::Result`].
 // XX: many of the jni crate checked methods do this automatically. We only need this if/when we invoke
@@ -24,56 +26,6 @@ pub fn try_catch<'jvm>(env: &mut JNIEnv<'jvm>) -> crate::Result<'jvm, ()> {
 }
 
 #[derive(Clone)]
-pub struct Catch<J, K> {
-    op: J,
-    catch: K,
-}
-
-impl<J, T, K> Catch<J, K>
-where
-    J: JvmOp,
-    T: Upcast<Throwable>,
-    K: JvmOp,
-    for<'jvm> K: JvmOp<Input<'jvm> = Local<'jvm, T>>,
-    for<'jvm> K::Output<'jvm>: Into<J::Output<'jvm>>,
-{
-    pub(crate) fn new(op: J, catch: impl FnOnce(ThrownOp<T>) -> K) -> Catch<J, K> {
-        let catch = catch(ThrownOp {
-            _marker: PhantomData,
-        });
-        Catch { op, catch }
-    }
-}
-
-impl<J, T, F> JvmOp for Catch<J, F>
-where
-    J: JvmOp,
-    T: Upcast<Throwable>,
-    F: JvmOp,
-    for<'jvm> F: JvmOp<Input<'jvm> = Local<'jvm, T>>,
-    for<'jvm> F::Output<'jvm>: Into<J::Output<'jvm>>,
-{
-    type Input<'jvm> = J::Input<'jvm>;
-    type Output<'jvm> = J::Output<'jvm>;
-
-    fn execute_with<'jvm>(
-        self,
-        jvm: &mut crate::Jvm<'jvm>,
-        arg: Self::Input<'jvm>,
-    ) -> crate::Result<'jvm, Self::Output<'jvm>> {
-        self.op.execute_with(jvm, arg).or_else(|e| {
-            let e = e.extract_thrown(jvm);
-            if let Error::Thrown(thrown) = &e {
-                if let Ok(caught) = thrown.try_downcast::<_, T>().execute(jvm)? {
-                    return self.catch.execute_with(jvm, caught).map(|v| v.into());
-                }
-            }
-            Err(e)
-        })
-    }
-}
-
-#[derive(Clone)]
 pub struct ThrownOp<T> {
     _marker: PhantomData<T>,
 }
@@ -88,5 +40,162 @@ impl<T: Upcast<Throwable>> JvmOp for ThrownOp<T> {
         thrown: Local<'jvm, T>,
     ) -> crate::Result<'jvm, Self::Output<'jvm>> {
         Ok(thrown)
+    }
+}
+
+#[derive(Clone)]
+pub struct Catching<J, C> {
+    op: J,
+    catch: C,
+}
+
+#[derive(Clone)]
+pub struct CatchNone {
+    _private: (),
+}
+
+pub struct CatchSome<P, T, J> {
+    prev: P,
+    _thrown: PhantomData<T>,
+    op: J,
+}
+
+#[derive(Clone)]
+pub struct Finally<C, J> {
+    catcher: C,
+    op: J,
+}
+
+impl<P: Clone, T, J: Clone> Clone for CatchSome<P, T, J> {
+    fn clone(&self) -> Self {
+        Self {
+            prev: self.prev.clone(),
+            _thrown: PhantomData,
+            op: self.op.clone(),
+        }
+    }
+}
+
+impl<J: JvmOp> Catching<J, CatchNone> {
+    pub(crate) fn new(op: J) -> Self {
+        Self {
+            op,
+            catch: CatchNone { _private: () },
+        }
+    }
+}
+
+impl<J: JvmOp, C> Catching<J, C> {
+    /// Catch any unhandled exception thrown by this operation as long as its of
+    /// type `T`. Use [`Throwable`] as `T` to catch any exception.
+    pub fn catch<T, K>(self, op: impl FnOnce(ThrownOp<T>) -> K) -> Catching<J, CatchSome<C, T, K>>
+    where
+        T: Upcast<Throwable>,
+        K: JvmOp,
+        for<'jvm> K: JvmOp<Input<'jvm> = Local<'jvm, T>>,
+        for<'jvm> K::Output<'jvm>: Into<J::Output<'jvm>>,
+    {
+        Catching {
+            op: self.op,
+            catch: CatchSome {
+                prev: self.catch,
+                _thrown: PhantomData,
+                op: op(ThrownOp {
+                    _marker: PhantomData,
+                }),
+            },
+        }
+    }
+
+    /// Execute `op` regardless of the current operation succeeding, catching an exception, or "bubbling up" an
+    /// unhandled exception. If `op` itself throws an exception that exception will be bubbled up instead.
+    pub fn finally<K>(self, op: K) -> Finally<Self, K>
+    where
+        for<'jvm> K: JvmOp<Input<'jvm> = (), Output<'jvm> = ()>,
+    {
+        Finally { catcher: self, op }
+    }
+}
+
+trait CatchArm<J: JvmOp> {
+    fn try_handle<'jvm>(
+        self,
+        jvm: &mut Jvm<'jvm>,
+        thrown: Local<'jvm, Throwable>,
+    ) -> crate::Result<'jvm, Result<J::Output<'jvm>, Local<'jvm, Throwable>>>;
+}
+
+impl<J: JvmOp> CatchArm<J> for CatchNone {
+    fn try_handle<'jvm>(
+        self,
+        _jvm: &mut Jvm<'jvm>,
+        thrown: Local<'jvm, Throwable>,
+    ) -> crate::Result<'jvm, Result<J::Output<'jvm>, Local<'jvm, Throwable>>> {
+        Ok(Err(thrown))
+    }
+}
+
+impl<J, P, T, K> CatchArm<J> for CatchSome<P, T, K>
+where
+    J: JvmOp,
+    P: CatchArm<J>,
+    T: Upcast<Throwable>,
+    for<'jvm> K: JvmOp<Input<'jvm> = Local<'jvm, T>>,
+    for<'jvm> K::Output<'jvm>: Into<J::Output<'jvm>>,
+{
+    fn try_handle<'jvm>(
+        self,
+        jvm: &mut Jvm<'jvm>,
+        thrown: Local<'jvm, Throwable>,
+    ) -> crate::Result<'jvm, Result<J::Output<'jvm>, Local<'jvm, Throwable>>> {
+        match self.prev.try_handle(jvm, thrown)? {
+            Ok(x) => Ok(Ok(x)),
+            Err(thrown) => match thrown.try_downcast::<Throwable, T>().execute(jvm)? {
+                Ok(can_catch) => Ok(Ok(self.op.execute_with(jvm, can_catch)?.into())),
+                Err(other) => Ok(Err(other.clone_in(jvm))),
+            },
+        }
+    }
+}
+
+impl<J, C: CatchArm<J>> JvmOp for Catching<J, C>
+where
+    J: JvmOp,
+{
+    type Input<'jvm> = J::Input<'jvm>;
+    type Output<'jvm> = J::Output<'jvm>;
+
+    fn execute_with<'jvm>(
+        self,
+        jvm: &mut Jvm<'jvm>,
+        arg: Self::Input<'jvm>,
+    ) -> crate::Result<'jvm, Self::Output<'jvm>> {
+        self.op
+            .execute_with(jvm, arg)
+            .or_else(|e| match e.extract_thrown(jvm) {
+                Error::Thrown(thrown) => self.catch.try_handle(jvm, thrown)?.map_err(Error::Thrown),
+                e => Err(e),
+            })
+    }
+}
+
+impl<J, K> JvmOp for Finally<J, K>
+where
+    J: JvmOp,
+    for<'jvm> K: JvmOp<Input<'jvm> = (), Output<'jvm> = ()>,
+{
+    type Input<'jvm> = J::Input<'jvm>;
+    type Output<'jvm> = J::Output<'jvm>;
+
+    fn execute_with<'jvm>(
+        self,
+        jvm: &mut Jvm<'jvm>,
+        arg: Self::Input<'jvm>,
+    ) -> crate::Result<'jvm, Self::Output<'jvm>> {
+        let result = self.catcher.execute_with(jvm, arg);
+        if matches!(result, Ok(_) | Err(Error::Thrown(_))) {
+            self.op.execute(jvm)?;
+        }
+        result
     }
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -16,9 +16,7 @@ where
     for<'jvm> K: JvmOp<Input<'jvm> = J::Output<'jvm>, Output<'jvm> = ()>,
 {
     pub(crate) fn new(j: J, op: impl FnOnce(ArgOp<J>) -> K) -> Inspect<J, K> {
-        let k = op(ArgOp {
-            phantom: PhantomData,
-        });
+        let k = op(ArgOp::arg());
         Inspect { j, k }
     }
 }
@@ -50,6 +48,14 @@ where
 #[derive(Clone)]
 pub struct ArgOp<J: JvmOp> {
     phantom: PhantomData<J>,
+}
+
+impl<J: JvmOp> ArgOp<J> {
+    pub(crate) fn arg() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<J> JvmOp for ArgOp<J>

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -16,7 +16,9 @@ where
     for<'jvm> K: JvmOp<Input<'jvm> = J::Output<'jvm>, Output<'jvm> = ()>,
 {
     pub(crate) fn new(j: J, op: impl FnOnce(ArgOp<J>) -> K) -> Inspect<J, K> {
-        let k = op(ArgOp::arg());
+        let k = op(ArgOp {
+            phantom: PhantomData,
+        });
         Inspect { j, k }
     }
 }
@@ -48,14 +50,6 @@ where
 #[derive(Clone)]
 pub struct ArgOp<J: JvmOp> {
     phantom: PhantomData<J>,
-}
-
-impl<J: JvmOp> ArgOp<J> {
-    pub(crate) fn arg() -> Self {
-        Self {
-            phantom: PhantomData,
-        }
-    }
 }
 
 impl<J> JvmOp for ArgOp<J>

--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -1,6 +1,6 @@
 use crate::{
     cast::{AsUpcast, TryDowncast, Upcast},
-    catch::{CatchNone, CatchSome, Catching, ThrownOp},
+    catch::{CatchNone, Catching},
     inspect::{ArgOp, Inspect},
     java::lang::{Class, ClassExt, Throwable},
     not_null::NotNull,
@@ -42,38 +42,6 @@ pub trait JvmOp: Sized {
         for<'jvm> K: JvmOp<Input<'jvm> = Self::Output<'jvm>, Output<'jvm> = ()>,
     {
         Inspect::new(self, op)
-    }
-
-    /// Catch any unhandled exception thrown by this operation as long as its of
-    /// type `T`. Use [`Throwable`] as `T` to catch any exception.
-    ///
-    /// Note that chaining multiple `catch` calls together is *not* the same as
-    /// multiple catch arms in Java! Subsecquent `catch` calls can catch exceptions
-    /// thrown from previous catch operations! Use [`Self::catching()`] instead to handle
-    /// multiple different exception types at once.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use duchess::{java::{self, lang::{ObjectExt, ThrowableExt}}, JvmOp, IntoVoid};
-    /// duchess::Jvm::with(|jvm| {
-    ///     java::lang::Object::new()
-    ///         .notify()
-    ///         .catch::<java::lang::Throwable, _>(|t| t.print_stack_trace())
-    ///         .execute(jvm)
-    /// });
-    /// ```
-    fn catch<T, K>(
-        self,
-        op: impl FnOnce(ThrownOp<T>) -> K,
-    ) -> Catching<Self, CatchSome<CatchNone, T, K>>
-    where
-        T: Upcast<Throwable>,
-        K: JvmOp,
-        for<'jvm> K: JvmOp<Input<'jvm> = Local<'jvm, T>>,
-        for<'jvm> K::Output<'jvm>: Into<Self::Output<'jvm>>,
-    {
-        Catching::new(self).catch(op)
     }
 
     /// Start a set of catch blocks that can handle exceptions thrown by `self`. Multiple

--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -49,7 +49,7 @@ pub trait JvmOp: Sized {
     ///
     /// Note that chaining multiple `catch` calls together is *not* the same as
     /// multiple catch arms in Java! Subsecquent `catch` calls can catch exceptions
-    /// thrown from previous catch operations! Use XX instead to handle multiple
+    /// thrown from previous catch operations! Use [`crate::by_type`] instead to handle multiple
     /// different exception types at once.
     ///
     /// # Example
@@ -209,7 +209,7 @@ impl<'jvm> Jvm<'jvm> {
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// # use duchess::JavaObject;
 /// pub struct BigDecimal {
 ///     _private: (), // prevent construction

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub use jvm::Local;
 pub use prelude::*;
 
 pub mod prelude {
+    pub use crate::cast::by_type;
     pub use crate::jvm::JvmOp;
     pub use crate::ops::{
         IntoJava, IntoLocal, IntoOptLocal, IntoRust, IntoScalar, IntoVoid, JavaMethod,


### PR DESCRIPTION
The `by_type!` macro allows users to write a pseudo-match expression
that tries to downcast a Java object into a given class or interface.

It's intended mainly for inspecting the output Java APIs that can throw different
kinds of exceptions for different error cases. 

---

Also add support for multiple catch arms and a `finally` block.