### PR TITLE
Recompile when CLASSPATH changes

### DIFF
--- a/macro/build.rs
+++ b/macro/build.rs
@@ -1,3 +1,8 @@
 fn main() {
     lalrpop::process_root().unwrap();
+
+    // Procedural macros currently do not automatically rerun when the environment variables on
+    // which they depend change. So, as a workaround we force a recompilation.
+    // See issue: https://github.com/duchess-rs/duchess/issues/7
+    println!("cargo:rerun-if-env-changed=CLASSPATH");
 }


### PR DESCRIPTION
This is a workaround for https://github.com/duchess-rs/duchess/issues/7. It forces a recompilation of the procedural macro whenever the `CLASSPATH` environment variable on which it depends changes.