### PR TITLE
Fix parsing of bytecode generated from Scala

### DIFF
--- a/macro/build.rs
+++ b/macro/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     lalrpop::process_root().unwrap();
 
+    // Recompile the crate when the lalrpop grammar changes
+    println!("cargo:rerun-if-changed=src");
+
     // Procedural macros currently do not automatically rerun when the environment variables on
     // which they depend change. So, as a workaround we force a recompilation.
     // See issue: https://github.com/duchess-rs/duchess/issues/7

--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -210,6 +210,12 @@ pub enum Privacy {
 }
 
 #[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+pub enum MemberFunction {
+    Constructor(Constructor),
+    Method(Method),
+}
+
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
 pub struct Constructor {
     pub flags: Flags,
     pub generics: Vec<Generic>,

--- a/macro/src/class_info/javap_parser.lalrpop
+++ b/macro/src/class_info/javap_parser.lalrpop
@@ -36,9 +36,16 @@ ClassInfoInline: ClassInfo = {
         <i:("implements" <Comma<ClassRef>>)?>
     "{" 
         <f:Field*>
-        <c:Constructor*>
-        <m:Method*>
+        <m:MemberFunction*>
     "}" => {
+        let mut constructors = vec![];
+        let mut methods = vec![];
+        for member in m.into_iter() {
+            match member {
+                MemberFunction::Constructor(c) => constructors.push(c),
+                MemberFunction::Method(m) => methods.push(m),
+            }
+        }
         ClassInfo {
             span: span,
             flags: l,
@@ -47,8 +54,8 @@ ClassInfoInline: ClassInfo = {
             generics: g,
             extends: e,
             implements: i.unwrap_or(vec![]),
-            constructors: c,
-            methods: m,
+            constructors,
+            methods,
             fields: f,
         }
     }
@@ -92,6 +99,11 @@ Id: Id = {
 
 ID: &'input str = {
     r"[a-zA-Z_$][a-zA-Z$0-9_]*"
+}
+
+MemberFunction: MemberFunction = {
+    <c:Constructor> => MemberFunction::Constructor(c),
+    <m:Method> => MemberFunction::Method(m),
 }
 
 Constructor: Constructor = {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -776,7 +776,7 @@ impl Signature {
             }
             RefType::TypeParameter(t) => {
                 assert!(
-                    self.in_scope_generics.contains(&t),
+                    self.in_scope_generics.contains(t),
                     "generic type parameter `{:?}` not among in-scope parameters: {:?}",
                     t,
                     self.in_scope_generics,

--- a/test-crates/viper/src/main.rs
+++ b/test-crates/viper/src/main.rs
@@ -1,6 +1,13 @@
 duchess::java_package! {
     package scala;
     class AnyVal { * }
+
+    package viper.silver.ast;
+    class Bool {}
+    class Int {}
+
+    package viper.silver.components;
+    class LifetimeComponent {}
 }
 
 fn main() {}


### PR DESCRIPTION
This PR improves the parsing of classes generated from Scala code:
* Support constructors listed after methods 
* Support generics with an upper bound, e.g. `<T extends viper.silver.ast.Node>`
* Add a missing `$` to the grammar of method descriptors

Fixes #36