### PR TITLE
Implement `JvmBuilder`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -58,12 +58,33 @@ pub struct JniError(#[from] pub(crate) JniErrorInternal);
 pub(crate) enum JniErrorInternal {
     #[error(transparent)]
     CheckFailure(#[from] jni::errors::Error),
+
     #[error(transparent)]
     Jni(#[from] jni::errors::JniError),
+
+    /// An internal error that can occur when invoking a JVM
+    #[error(transparent)]
+    JvmError(#[from] jni::JvmError),
+
+    /// An internal JNI error that can occur when invoking a JVM
+    #[error(transparent)]
+    StartJvmError(#[from] jni::errors::StartJvmError),
 }
 
 impl<T> From<jni::errors::JniError> for Error<T> {
     fn from(value: jni::errors::JniError) -> Self {
+        Self::from(JniError::from(JniErrorInternal::from(value)))
+    }
+}
+
+impl<T> From<jni::JvmError> for Error<T> {
+    fn from(value: jni::JvmError) -> Self {
+        Self::from(JniError::from(JniErrorInternal::from(value)))
+    }
+}
+
+impl<T> From<jni::errors::StartJvmError> for Error<T> {
+    fn from(value: jni::errors::StartJvmError) -> Self {
         Self::from(JniError::from(JniErrorInternal::from(value)))
     }
 }

--- a/test-crates/viper/tests/test.rs
+++ b/test-crates/viper/tests/test.rs
@@ -1,7 +1,16 @@
 use duchess::prelude::*;
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+
+fn setup_tests() {
+    let classpath = std::env::var("CLASSPATH").unwrap();
+    duchess::Jvm::builder().add_classpath(classpath).launch(|_jvm| Ok(())).unwrap();
+}
 
 #[test]
 fn test_construct_silicon() -> duchess::GlobalResult<()> {
+    INIT.call_once(setup_tests);
     duchess::Jvm::with(|jvm| {
         use viper::viper::silicon::Silicon;
         let _silicon = Silicon::new().execute(jvm)?;

--- a/tests/bad_jvm_construction_1.rs
+++ b/tests/bad_jvm_construction_1.rs
@@ -1,0 +1,8 @@
+use duchess::Jvm;
+
+#[test]
+fn test_jvm_construction_error() {
+    Jvm::with(|_jvm| Ok(())).unwrap();
+    let res = Jvm::builder().launch(|_jvm| Ok(()));
+    assert!(res.is_err());
+}

--- a/tests/bad_jvm_construction_2.rs
+++ b/tests/bad_jvm_construction_2.rs
@@ -1,0 +1,8 @@
+use duchess::Jvm;
+
+#[test]
+fn test_jvm_construction_error() {
+    Jvm::builder().launch(|_jvm| Ok(())).unwrap();
+    let res = Jvm::builder().launch(|_jvm| Ok(()));
+    assert!(res.is_err());
+}

--- a/tests/good_jvm_construction_1.rs
+++ b/tests/good_jvm_construction_1.rs
@@ -1,0 +1,8 @@
+use duchess::Jvm;
+
+#[test]
+fn test_jvm_construction() {
+    Jvm::with(|_jvm| Ok(())).unwrap();
+    Jvm::with(|_jvm| Ok(())).unwrap();
+    Jvm::with(|_jvm| Ok(())).unwrap();
+}

--- a/tests/good_jvm_construction_2.rs
+++ b/tests/good_jvm_construction_2.rs
@@ -1,0 +1,8 @@
+use duchess::Jvm;
+
+#[test]
+fn test_jvm_construction() {
+    Jvm::builder().launch(|_jvm| Ok(())).unwrap();
+    Jvm::with(|_jvm| Ok(())).unwrap();
+    Jvm::with(|_jvm| Ok(())).unwrap();
+}


### PR DESCRIPTION
Implementation of what described in https://github.com/duchess-rs/duchess/issues/6. The global JVM is stored in a `once_cell::sync::OnceCell` to ensure that it's only constructed once via duchess' API. Other types that I considered and discarded:
* `once_cell::sync::Lazy` has no way of postponing the declaration of the constructor,
* `once_cell::race::onceBox` doesn't prevent concurrent invocations of the constructor, 
* `std::sync::OnceLock` depends on unstable features.

Fixes #6.