### PR TITLE
Parse interfaces with multiple extends

### DIFF
--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -133,7 +133,7 @@ pub struct ClassInfo {
     pub name: DotId,
     pub kind: ClassKind,
     pub generics: Vec<Generic>,
-    pub extends: Option<ClassRef>,
+    pub extends: Vec<ClassRef>,
     pub implements: Vec<ClassRef>,
     pub constructors: Vec<Constructor>,
     pub fields: Vec<Field>,

--- a/macro/src/class_info/javap_parser.lalrpop
+++ b/macro/src/class_info/javap_parser.lalrpop
@@ -24,17 +24,17 @@ ReflectedClassInfo: ReflectedClassInfo = {
 
 ClassName: DotId = {
     <Id> => DotId::from(<>),
-    DotId => <>,  
+    DotId => <>,
 };
 
 #[inline]
 ClassInfoInline: ClassInfo = {
-    Header? 
-    <l:Flags> <k:ClassKind> <n:ClassName> 
+    Header?
+    <l:Flags> <k:ClassKind> <n:ClassName>
         <g:Generics>
-        <e:("extends" <ClassRef>)?>
+        <e:("extends" <Comma<ClassRef>>)?>
         <i:("implements" <Comma<ClassRef>>)?>
-    "{" 
+    "{"
         <f:Field*>
         <m:MemberFunction*>
     "}" => {
@@ -52,7 +52,7 @@ ClassInfoInline: ClassInfo = {
             name: n,
             kind: k,
             generics: g,
-            extends: e,
+            extends: e.unwrap_or(vec![]),
             implements: i.unwrap_or(vec![]),
             constructors,
             methods,

--- a/test-crates/viper/src/lib.rs
+++ b/test-crates/viper/src/lib.rs
@@ -2,6 +2,10 @@ duchess::java_package! {
     package scala;
     class AnyVal { * }
     class Function1 {}
+    class Tuple2<T1, T2> {}
+
+    package scala.collection.immutable;
+    interface Seq<A> {}
 
     package viper.silver.ast;
     class Bool {}
@@ -10,11 +14,16 @@ duchess::java_package! {
     package viper.silver.frontend;
     class SilFrontend {}
 
+    package viper.silver.reporter;
+    interface Reporter {}
+
     package viper.silicon;
     class Silicon {
         viper.silicon.Silicon();
     }
 
     package viper.carbon;
-    class Carbon {}
+    class CarbonVerifier {
+        viper.carbon.CarbonVerifier(viper.silver.reporter.Reporter, scala.collection.immutable.Seq<scala.Tuple2<java.lang.String, java.lang.Object>>);
+    }
 }


### PR DESCRIPTION
Fix the grammar to support `interface Foo extends A, B, C`.