### PR TITLE
Use `jni-sys` directly instead of through `jni`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,20 @@ description = "Experiments with Java-Rust interop"
 [dependencies]
 derive_more = "0.99.17"
 duchess-macro = { path = "macro" }
-jni = { version = "0.21.1", features = ["invocation"] }
+jni-sys = "0.3.0"
+cesu8 = "1.1.0"
 once_cell = "1.17.1"
 thiserror = "1.0.40"
+tracing = "0.1.37"
+java-locator = { version = "0.1.3", optional = true }
+libloading = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 expect-test = "1.4.1"
+
+[features]
+default = ["dylibjvm"]
+dylibjvm = [
+    "java-locator",
+    "libloading",
+]

--- a/book/src/internals.md
+++ b/book/src/internals.md
@@ -51,14 +51,7 @@ The [JNI exposes Java exception state](https://docs.oracle.com/javase/7/docs/tec
  * `ExceptionOccurred()` returning a local reference to the thrown object
  * `ExceptionClear()` clearing the exception (if any)
 
-If an exception has occurred and isn't cleared before the next JNI call, the invoked Java code will immediately "see" the exception. Since this can cause an exception to propagate outside of the normal stack bubble-up, the `jni` crate always calls `ExceptionCheck` after all JNI calls and returns `Err(jni::errors::Error::JavaException)` if one has occurred. 
-
-The `JavaException` value isn't useful on its own since it doesn't contain a reference to the thrown object. Also, if we were to expose it directly to users who may ignore the `Err` case of a Duchess result, the exception would be left uncleared and poison the next JNI call. We therefore wrap all `jni` calls with `duchess::plumbing::with_jni_env()` to check for the `JavaException` error, materialize the thrown object into `duchess::Error::Thrown(obj)`, and clear the exception state. 
-
-## `jni` crate conventions
-
-While we may unwind our dendency on the `jni` crate wrappers over the JNI, for now we have the following conventions for using `jni` functions:
- 1. All `jni` functions that return a `Result` must be called inside of `duchess::plumbing::with_jni_env()` to properly materialize and clear exception state between JNI calls. See [Exceptions](#exceptions).
+If an exception has occurred and isn't cleared before the next JNI call, the invoked Java code will immediately "see" the exception. Since this can cause an exception to propagate outside of the normal stack bubble-up, we must always call `duchess::error::check_exception()?` after any JNI call that could throw. It will return `Err(duchess::Error::Thrown)` if one has occurred. 
 
 ## Frequently asked questions
 

--- a/book/src/jvm.md
+++ b/book/src/jvm.md
@@ -23,10 +23,6 @@ Jvm::builder()
     .add_classpath("bar")
     .memory()
     .custom("-X foobar")
-    .launch(|jvm| {
-
-    })
+    .launch_or_use_existing()
 ```
-
-Unlike the `with` command, the `launch` command panics if the JVM has already been started by some other thread.
 

--- a/book/src/reference.md
+++ b/book/src/reference.md
@@ -1,1 +1,7 @@
 # Reference
+
+## Features
+
+### `dylibjvm`
+
+`libjvm` can be either statically or dynamically linked. If the `dylibjvm` feature is enabled, `duchess` will dynamically load `libjvm` when trying to create or find a JVM. Unless the lib path is specified in `JvmBuilder::load_libjvm_at()`, it uses the `java-locator` crate to find the likely location of `libjvm` on the platform.

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -25,9 +25,18 @@ mod java_auth {
 
     // XX: can be removed when we automatically look through extends/implements
     use duchess::java;
-    unsafe impl duchess::plumbing::Upcast<java::lang::Throwable> for AuthenticationExceptionUnauthenticated {}
-    unsafe impl duchess::plumbing::Upcast<java::lang::Throwable> for AuthenticationExceptionInvalidSecurityToken {}
-    unsafe impl duchess::plumbing::Upcast<java::lang::Throwable> for AuthenticationExceptionInvalidSignature {}
+    unsafe impl duchess::plumbing::Upcast<java::lang::Throwable>
+        for AuthenticationExceptionUnauthenticated
+    {
+    }
+    unsafe impl duchess::plumbing::Upcast<java::lang::Throwable>
+        for AuthenticationExceptionInvalidSecurityToken
+    {
+    }
+    unsafe impl duchess::plumbing::Upcast<java::lang::Throwable>
+        for AuthenticationExceptionInvalidSignature
+    {
+    }
     unsafe impl duchess::plumbing::Upcast<java::lang::Throwable> for AuthorizationExceptionDenied {}
 
     pub use auth::*;

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -81,7 +81,7 @@ where
         };
 
         if is_inst {
-            // XX: Safety: just shown that jobject instanceof To::class
+            // SAFETY: just shown that jobject instanceof To::class
             let casted = unsafe { std::mem::transmute::<&From, &To>(instance.as_ref()) };
             Ok(Ok(jvm.local(casted)))
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,6 @@ pub enum Error<T: AsRef<Throwable>> {
     #[error(transparent)]
     UnableToLoadLibjvm(#[from] Box<dyn std::error::Error + Send + 'static>),
 
-    /// XX: name?
     #[error("{0}")]
     JvmInternal(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,16 @@
-use std::{fmt::Debug, result};
-
-use jni::{
-    objects::{AutoLocal, JObject},
-    JNIEnv,
+use std::{
+    fmt::{Debug, Display},
+    result,
 };
+
 use thiserror::Error;
 
-use crate::{java::lang::Throwable, Global, Jvm, Local};
+use crate::{
+    java::lang::{Throwable, ThrowableExt},
+    ops::IntoRust,
+    raw::{HasEnvPtr, ObjectPtr},
+    Global, Jvm, JvmOp, Local,
+};
 
 /// Result returned by most Java operations that may contain a local reference
 /// to a thrown exception.
@@ -17,22 +21,45 @@ pub type Result<'jvm, T> = result::Result<T, Error<Local<'jvm, Throwable>>>;
 pub type GlobalResult<T> = result::Result<T, Error<Global<Throwable>>>;
 
 #[derive(Error)]
-pub enum Error<T> {
+pub enum Error<T: AsRef<Throwable>> {
     /// A reference to an uncaught Java exception
-    #[error("Java invocation threw")]
+    #[error("Java invocation threw: {}", try_extract_message(.0))]
     Thrown(T),
 
-    /// An internal JNI error occurred
+    #[error(
+        "slice was too long (`{0}`) to convert to a Java array, which are limited to `i32::MAX`"
+    )]
+    SliceTooLong(usize),
+
+    #[error("attempted to deref a null Java object pointer")]
+    NullDeref,
+
+    #[error("attempted to nest `Jvm::with` calls")]
+    NestedUsage,
+
+    #[error("JVM already exists")]
+    JvmAlreadyExists,
+
+    #[cfg(feature = "dylibjvm")]
     #[error(transparent)]
-    Jni(#[from] JniError),
+    UnableToLoadLibjvm(#[from] Box<dyn std::error::Error + Send + 'static>),
+
+    /// XX: name?
+    #[error("{0}")]
+    JvmInternal(String),
 }
 
-impl<T> Debug for Error<T> {
+fn try_extract_message(exception: impl AsRef<Throwable>) -> String {
+    let message = Jvm::with(|jvm| {
+        let exception = jvm.local(exception.as_ref());
+        exception.to_string().assert_not_null().into_rust(jvm)
+    });
+    message.unwrap_or_else(|_| "<unable to get exception message>".into())
+}
+
+impl<T: AsRef<Throwable>> Debug for Error<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Thrown(_t) => f.debug_tuple("Thrown").finish(),
-            Self::Jni(e) => e.fmt(f),
-        }
+        Display::fmt(self, f)
     }
 }
 
@@ -40,153 +67,28 @@ impl<'jvm> Error<Local<'jvm, Throwable>> {
     pub fn into_global(self, jvm: &mut Jvm<'jvm>) -> Error<Global<Throwable>> {
         match self {
             Error::Thrown(t) => Error::Thrown(jvm.global(&t)),
-            Error::Jni(e) => Error::Jni(e),
+            Error::SliceTooLong(s) => Error::SliceTooLong(s),
+            Error::NullDeref => Error::NullDeref,
+            Error::NestedUsage => Error::NestedUsage,
+            Error::JvmAlreadyExists => Error::JvmAlreadyExists,
+            #[cfg(feature = "dylibjvm")]
+            Error::UnableToLoadLibjvm(e) => Error::UnableToLoadLibjvm(e),
+            Error::JvmInternal(m) => Error::JvmInternal(m),
         }
     }
 }
 
-/// An error ocurred invoking the JNI bridge.
-///
-/// XX: can we say that is either a duchess bug or a mismatch between the Java
-/// interface the rust code was compiled with and what was run? What other cases
-/// are there?
-#[derive(Error, Debug)]
-#[error(transparent)]
-pub struct JniError(#[from] pub(crate) JniErrorInternal);
-
-#[derive(Error, Debug)]
-pub(crate) enum JniErrorInternal {
-    #[error(transparent)]
-    CheckFailure(#[from] jni::errors::Error),
-
-    #[error(transparent)]
-    Jni(#[from] jni::errors::JniError),
-
-    /// An internal error that can occur when invoking a JVM
-    #[error(transparent)]
-    JvmError(#[from] jni::JvmError),
-
-    /// An internal JNI error that can occur when invoking a JVM
-    #[error(transparent)]
-    StartJvmError(#[from] jni::errors::StartJvmError),
-}
-
-impl<T> From<jni::errors::JniError> for Error<T> {
-    fn from(value: jni::errors::JniError) -> Self {
-        Self::from(JniError::from(JniErrorInternal::from(value)))
-    }
-}
-
-impl<T> From<jni::JvmError> for Error<T> {
-    fn from(value: jni::JvmError) -> Self {
-        Self::from(JniError::from(JniErrorInternal::from(value)))
-    }
-}
-
-impl<T> From<jni::errors::StartJvmError> for Error<T> {
-    fn from(value: jni::errors::StartJvmError) -> Self {
-        Self::from(JniError::from(JniErrorInternal::from(value)))
-    }
-}
-
-/// Plumbing utility to wrap an operation using the [`jni`] crate [`JNIEnv`] that will check for, and materialize,
-/// thrown exceptions. This should be the default way to convert [`jni::errors::Result`]s into Duchess [`Result`]s in
-/// generated code.
-///
-/// # Motivation
-///
-/// Why always check for and materialize exceptions? A Duchess user can execute most [`crate::JvmOp`]s at any time
-/// inside of a [`crate::Jvm::with()`] call. The returned [`Result`] should correctly contain an [`Error::Thrown`] if
-/// a Java exception was thrown. If we waited to materialize errors until exiting `with` or in a `catching()` block,
-/// the execute call would return an internal [`Error::Jni`] instead and the exception would be buried.
-///
-pub fn with_jni_env<'jvm, T>(
-    env: &mut JNIEnv<'jvm>,
-    f: impl FnOnce(&mut JNIEnv<'jvm>) -> jni::errors::Result<T>,
-) -> Result<'jvm, T> {
-    let result = f(env);
-    result.map_err(|e| match e {
-        jni::errors::Error::JavaException => {
-            let exception = match env.exception_occurred() {
-                Ok(ex) => ex,
-                Err(e) => return convert_non_throw_jni_error(e),
-            };
-            assert!(!exception.is_null());
-            if let Err(e) = env.exception_clear() {
-                return convert_non_throw_jni_error(e);
-            }
-            Error::Thrown(unsafe {
-                Local::from_jni(AutoLocal::new(JObject::from(exception), &env))
-            })
-        }
-        error => convert_non_throw_jni_error(error),
-    })
-}
-
-/// Plumbing utility to convert any [`jni::errors::Error`] that *isn't* from a thrown exception. This doesn't require
-/// a [`JNIEnv`] borrow and can be used in more contexts. However, it isn't implemented as an [`Into`] to avoid masking
-/// scenarios that do require an explicit exception check via [`with_jni_env()`].
-///
-/// # Panics
-///
-/// Panics if the error indicates a thrown Java exception.
-pub fn convert_non_throw_jni_error<T>(error: jni::errors::Error) -> Error<T> {
-    assert!(!matches!(error, jni::errors::Error::JavaException));
-    Error::from(JniError::from(JniErrorInternal::from(error)))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        java::{self, lang::ThrowableExt, util::ArrayListExt},
-        prelude::*,
-    };
-
-    #[test]
-    fn with_jni_env_materializes_thrown_exceptions() {
-        Jvm::with(|jvm| {
-            let env = jvm.to_env();
-            // set exception state
-            env.throw_new("java/lang/Throwable", "some thrown exception")
-                .unwrap();
-            let err = with_jni_env(env, |_env| Err::<(), _>(jni::errors::Error::JavaException))
-                .unwrap_err();
-            let Error::Thrown(t) = err else { panic!("expected materialized exception"); };
-            assert_eq!(
-                "some thrown exception",
-                t.get_message().assert_not_null().into_rust(jvm).unwrap()
-            );
-            Ok(())
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn with_jni_env_maps_everything_else_to_jni() {
-        Jvm::with(|jvm| {
-            let err = with_jni_env(jvm.to_env(), |_env| {
-                Err::<(), _>(jni::errors::Error::TryLock)
-            })
-            .unwrap_err();
-            assert!(matches!(err, Error::Jni(_)));
-            Ok(())
-        })
-        .unwrap();
-    }
-
-    // XX this should likely move to an integration test suite
-    #[test]
-    fn exceptions_from_duchess_generated_types_are_materialized_without_a_catch() {
-        Jvm::with(|jvm| {
-            let list = java::util::ArrayList::<java::lang::Object>::new()
-                .execute(jvm)
-                .unwrap();
-            // -2 is an illegal from index, throws
-            let err = list.sub_list(-2, 0).execute(jvm).err().unwrap();
-            assert!(matches!(err, Error::Thrown(_)));
-            Ok(())
-        })
-        .unwrap();
+/// Used by codegen to check if the JVM exception flag is set, materializing an [`Error::Thrown`] if it is.
+#[doc(hidden)]
+pub fn check_exception<'jvm>(jvm: &mut Jvm<'jvm>) -> Result<'jvm, ()> {
+    let env = jvm.env();
+    // SAFETY: we don't hold on to the return env ptr
+    let thrown = unsafe { env.invoke(|env| env.ExceptionOccurred, |env, f| f(env)) };
+    if let Some(thrown) = ObjectPtr::new(thrown) {
+        unsafe { env.invoke(|env| env.ExceptionClear, |env, f| f(env)) };
+        // SAFETY: the ptr returned by ExceptionOccurred is already a local ref and must be an instance of Throwable
+        Err(Error::Thrown(unsafe { Local::from_raw(env, thrown) }))
+    } else {
+        Ok(())
     }
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,0 +1,71 @@
+use std::ffi::CStr;
+
+use crate::{
+    java,
+    jvm::JavaObjectExt,
+    plumbing::{check_exception, HasEnvPtr},
+    raw::{MethodPtr, ObjectPtr},
+    Jvm, Local, Result,
+};
+
+pub fn find_class<'jvm>(
+    jvm: &mut Jvm<'jvm>,
+    jni_name: &CStr,
+) -> Result<'jvm, Local<'jvm, java::lang::Class>> {
+    let env = jvm.env();
+    let class = unsafe { env.invoke(|env| env.FindClass, |env, f| f(env, jni_name.as_ptr())) };
+    if let Some(class) = ObjectPtr::new(class) {
+        Ok(unsafe { Local::from_raw(env, class) })
+    } else {
+        check_exception(jvm)?;
+        // Class not existing should've triggered NoClassDefFoundError so something strange is now happening
+        Err(crate::Error::JvmInternal(format!(
+            "failed to find class `{}`",
+            jni_name.to_string_lossy()
+        )))
+    }
+}
+
+pub fn find_method<'jvm>(
+    jvm: &mut Jvm<'jvm>,
+    class: impl AsRef<java::lang::Class>,
+    jni_name: &CStr,
+    jni_descriptor: &CStr,
+) -> Result<'jvm, MethodPtr> {
+    let class = class.as_ref().as_raw();
+
+    let env = jvm.env();
+    let method = unsafe {
+        env.invoke(
+            |env| env.GetMethodID,
+            |env, f| {
+                f(
+                    env,
+                    class.as_ptr(),
+                    jni_name.as_ptr(),
+                    jni_descriptor.as_ptr(),
+                )
+            },
+        )
+    };
+    if let Some(method) = MethodPtr::new(method) {
+        Ok(method)
+    } else {
+        check_exception(jvm)?;
+        // Method not existing should've triggered NoSuchMethodError so something strange is now happening
+        Err(crate::Error::JvmInternal(format!(
+            "failed to find method `{}` with signature `{}`",
+            jni_name.to_string_lossy(),
+            jni_descriptor.to_string_lossy(),
+        )))
+    }
+}
+
+pub fn find_constructor<'jvm>(
+    jvm: &mut Jvm<'jvm>,
+    class: impl AsRef<java::lang::Class>,
+    jni_descriptor: &CStr,
+) -> Result<'jvm, MethodPtr> {
+    const METHOD_NAME: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"<init>\0") };
+    find_method(jvm, class, METHOD_NAME, jni_descriptor)
+}

--- a/src/java.rs
+++ b/src/java.rs
@@ -218,3 +218,4 @@ pub use auto::java::*;
 // XX this isn't a real class in the JVM, since each array type (e.g. Foo[] and int[]) is just a subclass of Object.
 // Should it go somewhere outside of the JDK core classes?
 pub use crate::array::JavaArray as Array;
+pub use crate::array::JavaArrayExt as ArrayExt;

--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -1,25 +1,16 @@
 use crate::{
     cast::{AsUpcast, TryDowncast, Upcast},
     catch::{CatchNone, Catching},
+    find::find_class,
     inspect::{ArgOp, Inspect},
     java::lang::{Class, ClassExt, Throwable},
     not_null::NotNull,
-    plumbing::{convert_non_throw_jni_error, with_jni_env},
-    IntoLocal,
+    raw::{self, EnvPtr, HasEnvPtr, JvmPtr, ObjectPtr},
+    thread, Error, Global, GlobalResult, IntoLocal, Local,
 };
 
-use std::{
-    borrow::Cow,
-    fmt::Display,
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-    ptr::NonNull,
-};
+use std::{ffi::CStr, fmt::Display, ptr::NonNull};
 
-use jni::{
-    objects::{AutoLocal, GlobalRef, JObject, JValueOwned},
-    sys, InitArgsBuilder, JNIEnv, JavaVM,
-};
 use once_cell::sync::OnceCell;
 
 /// A "jdk op" is a suspended operation that, when executed, will run
@@ -106,119 +97,134 @@ pub trait JvmOp: Sized {
 pub trait IsVoid: Default {}
 impl IsVoid for () {}
 
-static GLOBAL_JVM: OnceCell<JavaVM> = OnceCell::new();
+static GLOBAL_JVM: OnceCell<JvmPtr> = OnceCell::new();
 
-#[repr(transparent)]
+fn get_or_default_init_jvm() -> crate::GlobalResult<JvmPtr> {
+    match GLOBAL_JVM.get() {
+        Some(jvm) => Ok(*jvm),
+        None => {
+            Jvm::builder().launch_or_use_existing()?;
+            Ok(*GLOBAL_JVM
+                .get()
+                .expect("launch_or_use_existing must set GLOBAL_JVM"))
+        }
+    }
+}
+
 pub struct Jvm<'jvm> {
-    env: JNIEnv<'jvm>,
+    jvm: JvmPtr,
+    env: EnvPtr<'jvm>,
 }
 
 impl<'jvm> Jvm<'jvm> {
-    fn get_or_default_init_jvm() -> crate::GlobalResult<&'static JavaVM> {
-        GLOBAL_JVM.get_or_try_init(|| {
-            let jvm = JvmBuilder::new().build_jvm()?;
-            Ok(jvm)
-        })
+    pub fn builder() -> JvmBuilder {
+        JvmBuilder::new()
     }
 
-    pub fn builder<'args>() -> JvmBuilder<'args> {
-        JvmBuilder::new()
+    pub fn attach_thread_permanently() -> crate::GlobalResult<()> {
+        thread::attach_permanently(get_or_default_init_jvm()?)?;
+        Ok(())
     }
 
     pub fn with<R>(
         op: impl for<'a> FnOnce(&mut Jvm<'a>) -> crate::Result<'a, R>,
     ) -> crate::GlobalResult<R> {
-        let guard = Self::get_or_default_init_jvm()?
-            .attach_current_thread()
-            .map_err(convert_non_throw_jni_error)?;
+        let jvm = get_or_default_init_jvm()?;
+        // SAFTEY: we won't deinitialize the JVM while the guard is live
+        let mut guard = unsafe { thread::attach(jvm)? };
 
-        // Safety condition: must not be used to create new references
-        // unless they are contained by `guard`. In this case, the
-        // cloned env is fully contained within the lifetime of `guard`
-        // and basically takes its place. The only purpose here is to
-        // avoid having two lifetime parameters on `Jvm`; trying to
-        // keep the interface simpler.
-        let env = unsafe { guard.unsafe_clone() };
+        let mut jvm = Jvm {
+            jvm,
+            env: guard.env(),
+        };
 
-        op(&mut Jvm { env }).map_err(|e| {
-            e.into_global(&mut Jvm {
-                env: unsafe { guard.unsafe_clone() },
-            })
-        })
-    }
-
-    pub fn to_env(&mut self) -> &mut JNIEnv<'jvm> {
-        &mut self.env
+        op(&mut jvm).map_err(|e| e.into_global(&mut jvm))
     }
 
     pub fn local<R>(&mut self, r: &R) -> Local<'jvm, R>
     where
         R: JavaObject,
     {
-        let env = self.to_env();
-        unsafe {
-            let raw = r.as_jobject();
-            assert!(!raw.is_null());
-            let new_local_ref = env.new_local_ref(&*raw).unwrap();
-            assert!(!new_local_ref.is_null());
-            Local::from_jni(AutoLocal::new(new_local_ref, &env))
-        }
+        Local::new(self.env, r)
     }
 
     pub fn global<R>(&mut self, r: &R) -> Global<R>
     where
         R: JavaObject,
     {
-        let env = self.to_env();
-        unsafe {
-            let raw = r.as_jobject();
-            assert!(!raw.is_null());
-            let new_global_ref = env.new_global_ref(&*raw).unwrap();
-            assert!(!new_global_ref.is_null());
-            Global::from_jni(new_global_ref)
-        }
+        Global::new(self.jvm, self.env, r)
     }
 }
 
-pub struct JvmBuilder<'args> {
-    args_builder: InitArgsBuilder<'args>,
+impl<'jvm> HasEnvPtr<'jvm> for Jvm<'jvm> {
+    fn env(&self) -> EnvPtr<'jvm> {
+        self.env
+    }
 }
 
-impl<'args> JvmBuilder<'args> {
+pub struct JvmBuilder {
+    options: Vec<String>,
+    #[cfg(feature = "dylibjvm")]
+    libjvm_path: Option<std::path::PathBuf>,
+}
+
+impl JvmBuilder {
     fn new() -> Self {
-        let args_builder = InitArgsBuilder::new()
-            .version(jni::JNIVersion::V8)
-            .option("-Xcheck:jni");
-        JvmBuilder {
-            args_builder
+        let mut this = Self {
+            options: vec![],
+            #[cfg(feature = "dylibjvm")]
+            libjvm_path: None,
+        };
+
+        if cfg!(debug_assertions) {
+            this = this.custom("-Xcheck:jni");
         }
+        if let Ok(classpath) = std::env::var("CLASSPATH") {
+            this = this.add_classpath(classpath);
+        }
+
+        this
     }
 
-    pub fn add_classpath(mut self, classpath: impl Display) -> Self {
-        self.args_builder = self.args_builder.option(format!("-Djava.class.path={classpath}"));
+    pub fn add_classpath(self, classpath: impl Display) -> Self {
+        self.custom(format!("-Djava.class.path={classpath}"))
+    }
+
+    pub fn custom(mut self, opt_string: impl Into<String>) -> Self {
+        self.options.push(opt_string.into());
         self
     }
 
-    pub fn custom(mut self, opt_string: impl AsRef<str> + Into<Cow<'args, str>>) -> Self {
-        self.args_builder = self.args_builder.option(opt_string);
+    #[cfg(feature = "dylibjvm")]
+    pub fn load_libjvm_at(mut self, path: impl AsRef<std::path::Path>) -> Self {
+        self.libjvm_path = Some(path.as_ref().into());
         self
     }
 
-    fn build_jvm(self) -> crate::GlobalResult<JavaVM> {
-        let jvm_args = self.args_builder.build()?;
-        let jvm = JavaVM::new(jvm_args)?;
-        Ok(jvm)
+    /// Launch a new JVM, returning [`Error::JvmAlreadyExists`] if one already exists.
+    pub fn try_launch(self) -> GlobalResult<()> {
+        #[cfg(feature = "dylibjvm")]
+        if let Some(path) = self.libjvm_path {
+            crate::libjvm::libjvm_or_load_at(&path)?;
+        }
+
+        let jvm = raw::try_create_jvm(self.options.into_iter())?;
+        GLOBAL_JVM
+            .set(jvm)
+            .expect("tried to launch multiple JVMs through duchess");
+
+        Ok(())
     }
 
-    /// Launch a new JVM, returning an error if one already exists.
-    pub fn launch<R>(
-        self, op: impl for<'a> FnOnce(&mut Jvm<'a>) -> crate::Result<'a, R>,
-    ) -> crate::GlobalResult<R> {
-        let jvm = self.build_jvm()?;
-        // This unwrap never fails, because in case a JVM already exists `build_jvm` would have
-        // failed first.
-        GLOBAL_JVM.set(jvm).unwrap();
-        Jvm::with(op)
+    pub fn launch_or_use_existing(self) -> GlobalResult<()> {
+        match self.try_launch() {
+            Err(Error::JvmAlreadyExists) => {
+                let jvm = raw::jvm()?.expect("JVM should already exist");
+                GLOBAL_JVM.set(jvm).unwrap();
+                Ok(())
+            }
+            result => result,
+        }
     }
 }
 
@@ -255,34 +261,18 @@ pub trait JavaObjectExt: Sized {
     // We use an extension trait, instead of just declaring these functions on the main JavaObject
     // trait, to prevent trait implementors from overriding the implementation of these functions.
 
-    fn from_jobject<'a>(obj: &'a JObject<'a>) -> Option<&'a Self>;
-    fn as_jobject(&self) -> BorrowedJObject<'_>;
+    unsafe fn from_raw<'a>(ptr: ObjectPtr) -> &'a Self;
+    fn as_raw(&self) -> ObjectPtr;
 }
 impl<T: JavaObject> JavaObjectExt for T {
-    fn from_jobject<'a>(obj: &'a JObject<'a>) -> Option<&'a Self> {
-        // SAFETY: I *think* the cast is sound, because:
-        //
-        // 1. A pointer to a suitably aligned `sys::_jobject` should also satisfy Self's alignment
-        //    requirement (trait rule #3)
-        // 2. Self is a zero-sized type (trait rule #1), so there are no invalid bit patterns to
-        //    worry about.
-        // 3. Self is a zero-sized type (trait rule #1), so there's no actual memory region that is
-        //    subject to the aliasing rules.
-        //
-        // XXX: Please check my homework.
-        Some(unsafe { NonNull::new(obj.as_raw())?.cast().as_ref() })
+    unsafe fn from_raw<'a>(ptr: ObjectPtr) -> &'a Self {
+        // XX: safety
+        unsafe { ptr.as_ref() }
     }
 
-    fn as_jobject(&self) -> BorrowedJObject<'_> {
-        let raw = (self as *const Self).cast_mut().cast::<sys::_jobject>();
-
-        // SAFETY: the only way to get a `&Self` is by calling `Self::from_jobject` (trait rule #1),
-        // so reconstructing the original JObject passed to `from_jni` should also be safe.
-        let obj = unsafe { JObject::from_raw(raw) };
-
-        // We must wrap the JObject to prevent anyone from calling `delete_local_ref` on it;
-        // otherwise, `self` could become dangling
-        BorrowedJObject::new(obj)
+    fn as_raw(&self) -> ObjectPtr {
+        // XX: safety
+        unsafe { NonNull::new_unchecked((self as *const Self).cast_mut()).cast() }.into()
     }
 }
 
@@ -305,13 +295,13 @@ macro_rules! scalar {
         $(
             unsafe impl JavaType for $rust {
                 fn array_class<'jvm>(jvm: &mut Jvm<'jvm>) -> crate::Result<'jvm, Local<'jvm, Class>> {
-                    let env = jvm.to_env();
-
+                    // XX: Safety
+                    const CLASS_NAME: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked($array_class) };
                     static CLASS: OnceCell<Global<crate::java::lang::Class>> = OnceCell::new();
+
                     let global = CLASS.get_or_try_init::<_, crate::Error<Local<Throwable>>>(|| {
-                        let class = with_jni_env(env, |env| env.find_class($array_class))?;
-                        let global = with_jni_env(env, |env| env.new_global_ref(class))?;
-                        Ok(unsafe { Global::from_jni(global) })
+                        let class = find_class(jvm, CLASS_NAME)?;
+                        Ok(jvm.global(&class))
                     })?;
                     Ok(jvm.local(global))
                 }
@@ -323,171 +313,14 @@ macro_rules! scalar {
 }
 
 scalar! {
-    bool: "[Z",
-    i8:   "[B",
-    i16:  "[S",
-    i32:  "[I",
-    i64:  "[J",
-    f32:  "[F",
-    f64:  "[D",
-}
-
-/// A wrapper for a [JObject] that only allows access by reference. This prevents passing the
-/// wrapped `JObject` to `JNIEnv::delete_local_ref`.
-pub type BorrowedJObject<'a> = Jail<JObject<'a>>;
-
-/// A wrapper for a value that prevents the value from being moved out, while still allowing access
-/// by reference.
-pub struct Jail<T>(T);
-
-impl<T> Jail<T> {
-    pub fn new(value: T) -> Self {
-        Self(value)
-    }
-}
-impl<T> Deref for Jail<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl<T> DerefMut for Jail<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-impl<T> AsRef<T> for Jail<T> {
-    fn as_ref(&self) -> &T {
-        &*self
-    }
-}
-impl<T> AsMut<T> for Jail<T> {
-    fn as_mut(&mut self) -> &mut T {
-        &mut *self
-    }
-}
-
-// I suspect we'll need to change these from type aliases to newtypes, for ergonomics sake, but for
-// now, they just work.
-
-/// An owned local reference to a non-null Java object of type `T`. The reference will be freed when
-/// dropped.
-pub type Local<'a, T> = OwnedRef<'a, AutoLocal<'a, JObject<'a>>, T>;
-
-/// An owned global reference to a non-null Java object of type `T`. The reference will be freed
-/// when dropped.
-pub type Global<T> = OwnedRef<'static, GlobalRef, T>;
-
-/// An *owned* JNI reference, either local or global, to a non-null Java object of type `T`. The
-/// underlying JNI reference is represented by type `J`, which is responsible for freeing the
-/// reference when dropped.
-///
-/// Typically, instead of using `OwnedRef` directly, you would use one of the type aliases, [Local]
-/// or [Global]. If you need a borrowed reference instead of an owned one, just use `&T`.
-#[repr(transparent)]
-pub struct OwnedRef<'a, J, T> {
-    inner: J,
-    phantom: PhantomData<&'a T>,
-}
-
-impl<J, T> OwnedRef<'_, J, T> {
-    /// Converts an underlying JNI reference into an [OwnedRef].
-    ///
-    /// # Safety
-    ///
-    /// `inner` must refer to a non-null Java object whose type is `T`.
-    pub unsafe fn from_jni(inner: J) -> Self {
-        Self {
-            inner,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<'a, J, T> Deref for OwnedRef<'a, J, T>
-where
-    J: Deref<Target = JObject<'a>>,
-    T: JavaObject,
-{
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        T::from_jobject(&*self.inner).expect("inner reference is null")
-    }
-}
-
-// pub(crate) trait IntoRawJObject {
-//     fn into_raw(self) -> sys::jobject;
-// }
-
-// impl IntoRawJObject for JObject<'_> {
-//     fn into_raw(self) -> sys::jobject {
-//         self.into_raw()
-//     }
-// }
-
-// impl IntoRawJObject for sys::jobject {
-//     fn into_raw(self) -> sys::jobject {
-//         self
-//     }
-// }
-
-// impl<R> IntoRawJObject for &R
-// where
-//     R: JavaObject,
-// {
-//     fn into_raw(self) -> sys::jobject {
-//         self.to_raw()
-//     }
-// }
-
-impl<'a, R, S> AsRef<S> for Local<'a, R>
-where
-    R: Upcast<S>,
-    S: JavaObject + 'a,
-{
-    fn as_ref(&self) -> &S {
-        // XX: Safety: repr(transparent) so OwnedRef<J, X> and OwnedRef<J, Y> have the same repr
-        let upcast: &Local<'a, S> = unsafe { std::mem::transmute(self) };
-        upcast
-    }
-}
-
-impl<'a, R> Local<'a, R> {
-    /// XX: Trying to map onto Into causes impl conflits
-    pub fn upcast<S>(self) -> Local<'a, S>
-    where
-        R: Upcast<S>,
-        S: JavaObject + 'a,
-    {
-        // XX: Safety: repr(transparent) so OwnedRef<J, X> and OwnedRef<J, Y> have the same repr
-        let upcast: Local<'a, S> = unsafe { std::mem::transmute(self) };
-        upcast
-    }
-}
-
-impl<R, S> AsRef<S> for Global<R>
-where
-    R: Upcast<S>,
-    S: JavaObject + 'static,
-{
-    fn as_ref(&self) -> &S {
-        // XX: Safety: repr(transparent) so OwnedRef<J, X> and OwnedRef<J, Y> have the same repr
-        let upcast: &Global<S> = unsafe { std::mem::transmute(self) };
-        upcast
-    }
-}
-
-impl<R> Global<R> {
-    /// XX: Trying to map onto Into causes impl conflits
-    pub fn upcast<S>(self) -> Global<S>
-    where
-        R: Upcast<S>,
-        S: JavaObject + 'static,
-    {
-        // XX: Safety: repr(transparent) so OwnedRef<J, X> and OwnedRef<J, Y> have the same repr
-        let upcast: Global<S> = unsafe { std::mem::transmute(self) };
-        upcast
-    }
+    bool: b"[Z\0",
+    i8:   b"[B\0",
+    i16:  b"[S\0",
+    u16:  b"[C\0",
+    i32:  b"[I\0",
+    i64:  b"[J\0",
+    f32:  b"[F\0",
+    f64:  b"[D\0",
 }
 
 pub trait CloneIn<'jvm> {
@@ -500,118 +333,5 @@ where
 {
     fn clone_in(&self, _jvm: &mut Jvm<'_>) -> Self {
         self.clone()
-    }
-}
-
-impl<'jvm, T> CloneIn<'jvm> for Local<'jvm, T>
-where
-    T: JavaObject,
-{
-    fn clone_in(&self, jvm: &mut Jvm<'jvm>) -> Self {
-        jvm.local(self)
-    }
-}
-
-impl<'jvm, T> CloneIn<'jvm> for Global<T>
-where
-    T: JavaObject,
-{
-    fn clone_in(&self, jvm: &mut Jvm<'jvm>) -> Self {
-        jvm.global(self)
-    }
-}
-
-pub trait FromJValue<'jvm> {
-    fn from_jvalue(jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self;
-}
-
-impl<'jvm, T> FromJValue<'jvm> for Option<Local<'jvm, T>>
-where
-    T: JavaObject,
-{
-    fn from_jvalue(jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Object(o) => {
-                if o.is_null() {
-                    None
-                } else {
-                    let env = jvm.to_env();
-                    Some(unsafe { Local::from_jni(AutoLocal::new(o, &env)) })
-                }
-            }
-            _ => panic!("expected object, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for () {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Void => (),
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for i32 {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Int(i) => i,
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for i64 {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Long(i) => i,
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for i8 {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Byte(i) => i,
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for i16 {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Short(i) => i,
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for bool {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Bool(i) => i != 0,
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for f32 {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Float(i) => i,
-            _ => panic!("expected void, found {value:?})"),
-        }
-    }
-}
-
-impl<'jvm> FromJValue<'jvm> for f64 {
-    fn from_jvalue(_jvm: &mut Jvm<'jvm>, value: JValueOwned<'jvm>) -> Self {
-        match value {
-            jni::objects::JValueGen::Double(i) => i,
-            _ => panic!("expected void, found {value:?})"),
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,28 +4,31 @@ mod array;
 mod cast;
 mod catch;
 mod error;
+mod find;
 mod inspect;
 mod jvm;
+mod libjvm;
 mod not_null;
 mod ops;
+mod raw;
+mod ref_;
 mod str;
+mod thread;
 
 /// Contains reusable declarations for classes distributed by the JDK under the `java.*` packages.
 pub mod java;
 
 pub use duchess_macro::java_package;
 pub use error::{Error, GlobalResult, Result};
-pub use jvm::Global;
 pub use jvm::JavaObject;
 pub use jvm::JavaType;
 pub use jvm::Jvm;
-pub use jvm::Local;
+pub use ref_::{Global, Local};
 
 pub use prelude::*;
 
 /// Re-export the dependencies that are used by the generated code.
 pub mod codegen_deps {
-    pub use jni;
     pub use once_cell;
 }
 
@@ -42,7 +45,8 @@ pub mod prelude {
 /// names used by generated code.
 pub mod plumbing {
     pub use crate::cast::Upcast;
-    pub use crate::error::{convert_non_throw_jni_error, with_jni_env};
-    pub use crate::jvm::{FromJValue, JavaObjectExt};
-    pub use crate::str::ToJavaStringOp;
+    pub use crate::error::check_exception;
+    pub use crate::find::{find_class, find_constructor, find_method};
+    pub use crate::jvm::JavaObjectExt;
+    pub use crate::raw::{FromJniValue, HasEnvPtr, IntoJniValue, MethodPtr, ObjectPtr};
 }

--- a/src/libjvm.rs
+++ b/src/libjvm.rs
@@ -1,0 +1,74 @@
+use crate::GlobalResult;
+
+/// Virtual table for top-level libjvm functions that create or get JVMs.
+#[allow(non_snake_case)]
+pub(crate) struct Libjvm {
+    pub JNI_CreateJavaVM: unsafe extern "system" fn(
+        pvm: *mut *mut jni_sys::JavaVM,
+        penv: *mut *mut std::ffi::c_void,
+        args: *mut std::ffi::c_void,
+    ) -> jni_sys::jint,
+    pub JNI_GetCreatedJavaVMs: unsafe extern "system" fn(
+        vmBuf: *mut *mut jni_sys::JavaVM,
+        bufLen: jni_sys::jsize,
+        nVMs: *mut jni_sys::jsize,
+    ) -> jni_sys::jint,
+}
+
+#[cfg(feature = "dylibjvm")]
+mod dynlib {
+    use std::path::{Path, PathBuf};
+
+    use libloading::Library;
+    use once_cell::sync::OnceCell;
+
+    use super::*;
+    use crate::Error;
+
+    static LIBJVM: OnceCell<Libjvm> = OnceCell::new();
+
+    #[allow(non_snake_case)]
+    fn load_libjvm_at(path: &Path) -> GlobalResult<Libjvm> {
+        (|| {
+            let lib = unsafe { Library::new(path) }?;
+            let JNI_CreateJavaVM = *unsafe { lib.get(b"JNI_CreateJavaVM\0") }?;
+            let JNI_GetCreatedJavaVMs = *unsafe { lib.get(b"JNI_GetCreatedJavaVMs\0") }?;
+            Ok(Libjvm {
+                JNI_CreateJavaVM,
+                JNI_GetCreatedJavaVMs,
+            })
+        })()
+        .map_err(|e: libloading::Error| Error::UnableToLoadLibjvm(Box::new(e)))
+    }
+
+    pub(crate) fn libjvm_or_load() -> GlobalResult<&'static Libjvm> {
+        LIBJVM.get_or_try_init(|| {
+            let path: PathBuf = [
+                &java_locator::locate_jvm_dyn_library()
+                    .map_err(|e| Error::UnableToLoadLibjvm(Box::new(e)))?,
+                java_locator::get_jvm_dyn_lib_file_name(),
+            ]
+            .into_iter()
+            .collect();
+
+            load_libjvm_at(&path)
+        })
+    }
+
+    pub(crate) fn libjvm_or_load_at(path: &Path) -> GlobalResult<&'static Libjvm> {
+        LIBJVM.get_or_try_init(|| load_libjvm_at(path))
+    }
+}
+
+#[cfg(feature = "dylibjvm")]
+pub(crate) use dynlib::{libjvm_or_load, libjvm_or_load_at};
+
+#[cfg(not(feature = "dylibjvm"))]
+pub(crate) fn libjvm_or_load() -> GlobalResult<&'static Libjvm> {
+    static LIBJVM: Libjvm = Libjvm {
+        JNI_CreateJavaVM: jni_sys::JNI_CreateJavaVM,
+        JNI_GetCreatedJavaVMs: jni_sys::JNI_GetCreatedJavaVMs,
+    };
+
+    Ok(&LIBJVM)
+}

--- a/src/libjvm.rs
+++ b/src/libjvm.rs
@@ -33,6 +33,7 @@ mod dynlib {
             let lib = unsafe { Library::new(path) }?;
             let JNI_CreateJavaVM = *unsafe { lib.get(b"JNI_CreateJavaVM\0") }?;
             let JNI_GetCreatedJavaVMs = *unsafe { lib.get(b"JNI_GetCreatedJavaVMs\0") }?;
+            std::mem::forget(lib); // We keep the JVM (and therefore libjvm) around through the end of the process
             Ok(Libjvm {
                 JNI_CreateJavaVM,
                 JNI_GetCreatedJavaVMs,

--- a/src/not_null.rs
+++ b/src/not_null.rs
@@ -1,4 +1,4 @@
-use crate::{plumbing::convert_non_throw_jni_error, JavaObject, JvmOp, Local};
+use crate::{Error, JavaObject, JvmOp, Local};
 
 #[derive(Clone)]
 pub struct NotNull<J: JvmOp> {
@@ -29,11 +29,6 @@ where
         input: J::Input<'jvm>,
     ) -> crate::Result<'jvm, Self::Output<'jvm>> {
         let j = self.j.execute_with(jvm, input)?;
-        match j {
-            Some(v) => Ok(v),
-            None => Err(convert_non_throw_jni_error(jni::errors::Error::NullDeref(
-                "not_null()",
-            ))),
-        }
+        j.ok_or(Error::NullDeref)
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -96,6 +96,8 @@ pub(crate) fn try_create_jvm<'a>(
             let Some(jvm) = JvmPtr::new(jvm) else {
                 return Err(Error::JvmInternal("JNI_CreateJavaVM returned null pointer".into()));
             };
+            // Undo default attaching of current thread like the jni crate does
+            unsafe { jvm.detach_thread() }?;
             Ok(jvm)
         }
         jni_sys::JNI_EEXIST => Err(Error::JvmAlreadyExists),

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,397 @@
+//! Contains newtypes for pointers vended by [`jni_sys`]. The newtypes must correctly impl Send and Sync (or not) and
+//! include correct lifetime bounds, but are otherwise "untyped". The class or interface the Java object they point to
+//! must be safely tracked elsewhere.
+//!
+//! The `'static` pointers generally rely on duchess not deinitializing a JVM after it's already initialized.
+
+use std::{
+    ffi,
+    marker::PhantomData,
+    ptr::{self, NonNull},
+};
+
+use jni_sys::jvalue;
+
+use crate::{jvm::JavaObjectExt, Error, GlobalResult, JavaObject, Jvm, Local};
+
+const VERSION: jni_sys::jint = jni_sys::JNI_VERSION_1_8;
+
+/// Get a [`JvmPtr`] to an already initialized JVM (if one exists).
+///
+/// If the `dynlibjvm` feature is enabled and `libjvm` isn't already loaded, it will first force it to be loaded.
+pub(crate) fn jvm() -> GlobalResult<Option<JvmPtr>> {
+    let libjvm = crate::libjvm::libjvm_or_load()?;
+
+    let mut jvms = [std::ptr::null_mut::<jni_sys::JavaVM>()];
+    let mut num_jvms: jni_sys::jsize = 0;
+
+    let code = unsafe {
+        (libjvm.JNI_GetCreatedJavaVMs)(
+            jvms.as_mut_ptr(),
+            jvms.len().try_into().unwrap(),
+            &mut num_jvms as *mut _,
+        )
+    };
+    if code != jni_sys::JNI_OK {
+        return Err(Error::JvmInternal(format!(
+            "GetCreatedJavaVMs failed with code `{code}`"
+        )));
+    }
+
+    match num_jvms {
+        0 => Ok(None),
+        1 => JvmPtr::new(jvms[0])
+            .ok_or_else(|| Error::JvmInternal("GetCreatedJavaVMs returned null pointer".into()))
+            .map(Some),
+        _ => Err(Error::JvmInternal(format!(
+            "GetCreatedJavaVMs returned more JVMs than expected: `{num_jvms}`"
+        ))),
+    }
+}
+
+/// Try to initialize a new JVM with the provided `options`, returning a [`JvmPtr`] on success or an
+/// [`Error::JvmAlreadyExists`] if one already exists.
+///
+/// If the `dynlibjvm` feature is enabled and `libjvm` isn't already loaded, it will first force it to be loaded.
+pub(crate) fn try_create_jvm<'a>(
+    options: impl IntoIterator<Item = String>,
+) -> GlobalResult<JvmPtr> {
+    let libjvm = crate::libjvm::libjvm_or_load()?;
+
+    let options = options
+        .into_iter()
+        .map(|opt| ffi::CString::new(opt).unwrap())
+        .collect::<Vec<_>>();
+
+    let mut option_ptrs = options
+        .iter()
+        .map(|opt| jni_sys::JavaVMOption {
+            optionString: opt.as_ptr().cast_mut(),
+            extraInfo: std::ptr::null_mut(),
+        })
+        .collect::<Vec<_>>();
+
+    let mut args = jni_sys::JavaVMInitArgs {
+        version: VERSION,
+        nOptions: options.len().try_into().unwrap(),
+        options: option_ptrs.as_mut_ptr(),
+        ignoreUnrecognized: jni_sys::JNI_FALSE,
+    };
+
+    let mut jvm = std::ptr::null_mut::<jni_sys::JavaVM>();
+    let mut env = std::ptr::null_mut::<ffi::c_void>();
+
+    // SAFETY: the C strings pointed to be options are valid and non-null through the end of the call. They're not
+    // needed once it returns.
+    let code = unsafe {
+        (libjvm.JNI_CreateJavaVM)(
+            &mut jvm as *mut _,
+            &mut env as *mut _,
+            &mut args as *mut _ as *mut ffi::c_void,
+        )
+    };
+
+    match code {
+        jni_sys::JNI_OK => {
+            let Some(jvm) = JvmPtr::new(jvm) else {
+                return Err(Error::JvmInternal("JNI_CreateJavaVM returned null pointer".into()));
+            };
+            Ok(jvm)
+        }
+        jni_sys::JNI_EEXIST => Err(Error::JvmAlreadyExists),
+        _ => Err(Error::JvmInternal(format!(
+            "CreateJavaVM failed with code `{code}`"
+        ))),
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct JvmPtr(NonNull<jni_sys::JavaVM>);
+
+impl JvmPtr {
+    pub(crate) fn new(ptr: *mut jni_sys::JavaVM) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    /// Returns an [`EnvPtr`] which can be used to invoke JNI methods on the current thread. Will return
+    /// `None` if the current thread isn't attached to the JVM.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the `'jvm` lifetime will not live past when the current thread is detached from the
+    /// JVM.
+    pub(crate) unsafe fn env<'jvm>(self) -> GlobalResult<Option<EnvPtr<'jvm>>> {
+        let mut env_ptr = std::ptr::null_mut::<ffi::c_void>();
+        match fn_table_call(
+            self.0,
+            |jvm| jvm.GetEnv,
+            |jvm, f| f(jvm, &mut env_ptr as *mut _, VERSION),
+        ) {
+            jni_sys::JNI_OK => Ok(Some(EnvPtr::new(env_ptr.cast()).unwrap())),
+            jni_sys::JNI_EDETACHED => Ok(None),
+            code => Err(Error::JvmInternal(format!(
+                "GetEnv failed with code `{code}`"
+            ))),
+        }
+    }
+
+    /// Attaches the current thread to the JVM and returns an [`EnvPtr`] that can be used to invoke JNI methods.
+    /// Multiple calls on the same thread are idempotent.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the `'jvm` lifetime will not live past when the current thread is detached from the
+    /// JVM.
+    pub(crate) unsafe fn attach_thread<'jvm>(self) -> GlobalResult<EnvPtr<'jvm>> {
+        let mut env_ptr = std::ptr::null_mut::<ffi::c_void>();
+        match fn_table_call(
+            self.0,
+            |jvm| jvm.AttachCurrentThread,
+            |jvm, f| {
+                f(
+                    jvm,
+                    &mut env_ptr as *mut _,
+                    std::ptr::null_mut(), /* args */
+                )
+            },
+        ) {
+            jni_sys::JNI_OK => Ok(EnvPtr::new(env_ptr.cast()).unwrap()),
+            code => Err(Error::JvmInternal(format!(
+                "AttachCurrentThread failed with code `{code}`"
+            ))),
+        }
+    }
+
+    /// Detaches the current thread from the JVM. Multiple calls on the same thread are idempotent.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that no local refs from the current thread are accessible.
+    pub(crate) unsafe fn detach_thread(self) -> GlobalResult<()> {
+        match fn_table_call(self.0, |jvm| jvm.DetachCurrentThread, |jvm, f| f(jvm)) {
+            jni_sys::JNI_OK => Ok(()),
+            code => Err(Error::JvmInternal(format!(
+                "DetachCurrentThread failed with code `{code}`"
+            ))),
+        }
+    }
+}
+
+/// Invokes a JNI function through a virtual table interface
+unsafe fn fn_table_call<T, F, R>(
+    table_ptr: NonNull<*const T>,
+    fn_field: impl FnOnce(&T) -> Option<F>,
+    call: impl FnOnce(*mut *const T, F) -> R,
+) -> R {
+    let fn_field = fn_field(&**table_ptr.as_ptr());
+    // SAFETY: We specify VERSION when accessing the JNI interfaces and libjvm promises these fn pointers will be
+    // non-null
+    let fn_field = fn_field.unwrap_unchecked();
+    call(table_ptr.as_ptr(), fn_field)
+}
+
+// SAFETY: The JVM pointer is safe to be used by any thread
+unsafe impl Send for JvmPtr {}
+unsafe impl Sync for JvmPtr {}
+
+/// Points to an attached JNI environment interface for the current thread that is valid through `'jvm`.
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct EnvPtr<'jvm> {
+    ptr: NonNull<jni_sys::JNIEnv>,
+    _marker: PhantomData<&'jvm ()>,
+}
+
+impl<'jvm> EnvPtr<'jvm> {
+    /// # Safety
+    ///
+    /// The caller must ensure that the JVM remains attached to the current thread throughout `'jvm`.
+    pub(crate) unsafe fn new(ptr: *mut jni_sys::JNIEnv) -> Option<Self> {
+        let ptr = NonNull::new(ptr)?;
+        Some(Self {
+            ptr,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Invoke a JNI method dispatched through a virtual table lookup. Used by codegen to make most JNI calls.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the [`jni_sys::JNIEnv`] raw pointer is only used for this invocation.
+    #[doc(hidden)]
+    pub unsafe fn invoke<F, T>(
+        self,
+        fn_field: impl FnOnce(&jni_sys::JNINativeInterface_) -> Option<F>,
+        call: impl FnOnce(*mut jni_sys::JNIEnv, F) -> T,
+    ) -> T {
+        fn_table_call(self.ptr, fn_field, call)
+    }
+}
+
+// Note: EnvPtr isn't Send/Sync!
+
+/// Trait used by codegen to get access to the raw [`EnvPtr`] on structs like [`Jvm`].
+#[doc(hidden)]
+pub trait HasEnvPtr<'jvm> {
+    fn env(&self) -> EnvPtr<'jvm>;
+}
+
+/// Points to a live Java object through either a local or global ref.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy)]
+pub struct ObjectPtr(NonNull<jni_sys::_jobject>);
+
+impl ObjectPtr {
+    /// Used by codegen to wrap JNI object pointers
+    #[doc(hidden)]
+    pub fn new(ptr: jni_sys::jobject) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    /// Used by codegen to invoke JNI calls on a Java object.
+    #[doc(hidden)]
+    pub fn as_ptr(self) -> jni_sys::jobject {
+        self.0.as_ptr()
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure that the pointed-to object remains live through `'a` and is an instance of `T` (or its
+    /// subclasses).
+    pub(crate) unsafe fn as_ref<'a, T: JavaObject>(self) -> &'a T {
+        // SAFETY: The cast is sound because:
+        //
+        // 1. A pointer to a suitably aligned `sys::_jobject` should also satisfy Self's alignment
+        //    requirement (trait rule #3)
+        // 2. Self is a zero-sized type (trait rule #1), so there are no invalid bit patterns to
+        //    worry about.
+        // 3. Self is a zero-sized type (trait rule #1), so there's no actual memory region that is
+        //    subject to the aliasing rules.
+        unsafe { self.0.cast().as_ref() }
+    }
+}
+
+impl From<NonNull<jni_sys::_jobject>> for ObjectPtr {
+    fn from(ptr: NonNull<jni_sys::_jobject>) -> Self {
+        Self(ptr)
+    }
+}
+
+// Note: ObjectPtrs are generally not safe to use across threads. Only ObjectPtrs that are global refs are.
+
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct MethodPtr(NonNull<jni_sys::_jmethodID>);
+
+impl MethodPtr {
+    pub(crate) fn new(ptr: jni_sys::jmethodID) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    #[doc(hidden)]
+    pub fn as_ptr(self) -> jni_sys::jmethodID {
+        self.0.as_ptr()
+    }
+}
+
+// The JNI promises method pointers remain valid for as long as the class is loaded and can be shared across threads
+unsafe impl Send for MethodPtr {}
+unsafe impl Sync for MethodPtr {}
+
+/// Trait used by codegen to convert into [`jni-sys`] unions.
+#[doc(hidden)]
+pub trait IntoJniValue {
+    fn into_jni_value(self) -> jvalue;
+}
+
+impl<T: JavaObject> IntoJniValue for &T {
+    fn into_jni_value(self) -> jvalue {
+        jvalue {
+            l: self.as_raw().as_ptr(),
+        }
+    }
+}
+
+impl<T: JavaObject> IntoJniValue for Option<&T> {
+    fn into_jni_value(self) -> jvalue {
+        self.map(|v| v.into_jni_value())
+            .unwrap_or(jvalue { l: ptr::null_mut() })
+    }
+}
+
+/// Trait used by codegen to extract the return value of a JNI call.
+#[doc(hidden)]
+pub trait FromJniValue<'jvm> {
+    type JniValue;
+    unsafe fn from_jni_value(jvm: &mut Jvm<'jvm>, value: Self::JniValue) -> Self;
+}
+
+impl<'jvm, T: JavaObject> FromJniValue<'jvm> for Option<Local<'jvm, T>> {
+    type JniValue = jni_sys::jobject;
+
+    unsafe fn from_jni_value(jvm: &mut Jvm<'jvm>, value: Self::JniValue) -> Self {
+        // SAFETY: objects returned by JNI calls are already local refs
+        ObjectPtr::new(value).map(|obj| unsafe { Local::from_raw(jvm.env(), obj) })
+    }
+}
+
+// () is Java `void`
+impl<'jvm> FromJniValue<'jvm> for () {
+    type JniValue = ();
+
+    unsafe fn from_jni_value(_jvm: &mut Jvm<'jvm>, _value: Self::JniValue) -> Self {
+        ()
+    }
+}
+
+macro_rules! scalar_jni_value {
+    ($($rust:ty: $field:ident $java:ident,)*) => {
+        $(
+            impl IntoJniValue for $rust {
+                fn into_jni_value(self) -> jvalue {
+                    jvalue {
+                        $field: self as jni_sys::$java,
+                    }
+                }
+            }
+
+            impl<'jvm> FromJniValue<'jvm> for $rust {
+                type JniValue = jni_sys::$java;
+
+                unsafe fn from_jni_value(_jvm: &mut Jvm<'jvm>, value: Self::JniValue) -> Self {
+                    value
+                }
+            }
+        )*
+    };
+}
+
+scalar_jni_value! {
+    // jboolean is u8, need to explicitly map to Rust bool
+    // bool: z jboolean,
+    i8: b jbyte,
+    i16: s jshort,
+    u16: c jchar,
+    i32: i jint,
+    i64: j jlong,
+    f32: f jfloat,
+    f64: d jdouble,
+}
+
+impl IntoJniValue for bool {
+    fn into_jni_value(self) -> jvalue {
+        jvalue {
+            z: self as jni_sys::jboolean,
+        }
+    }
+}
+
+impl<'jvm> FromJniValue<'jvm> for bool {
+    type JniValue = jni_sys::jboolean;
+
+    unsafe fn from_jni_value(_jvm: &mut Jvm<'jvm>, value: Self::JniValue) -> Self {
+        value == jni_sys::JNI_TRUE
+    }
+}

--- a/src/ref_.rs
+++ b/src/ref_.rs
@@ -1,0 +1,208 @@
+use std::{marker::PhantomData, ops::Deref, ptr::NonNull};
+
+use crate::jvm::JavaObjectExt;
+use crate::thread;
+use crate::{
+    cast::Upcast,
+    jvm::CloneIn,
+    plumbing::ObjectPtr,
+    raw::{EnvPtr, JvmPtr},
+    JavaObject, Jvm,
+};
+
+/// An owned local reference to a non-null Java object of type `T`. The reference will be freed when
+/// dropped. Cannot be shared across threads or [`Jvm::with`] invocations.
+pub struct Local<'jvm, T: JavaObject> {
+    env: EnvPtr<'jvm>,
+    obj: ObjectPtr,
+    _marker: PhantomData<T>,
+}
+
+impl<'jvm, T: JavaObject> Local<'jvm, T> {
+    /// Convert an existing local reference pointed to by `obj` into an owned `Local`. This is used by
+    /// codegen to wrap the output of most JNI calls to prevent the user from not freeing local refs.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `obj` points to a Java object that is an instance of `T` (or its subclasses), is a
+    /// a live, local reference in the current frame, will not later be deleted (including through another call to
+    /// `from_raw()`), and will not dereferenced after the returned [`Local`] is dropped.
+    #[doc(hidden)]
+    pub unsafe fn from_raw(env: EnvPtr<'jvm>, obj: ObjectPtr) -> Self {
+        Self {
+            obj,
+            env,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a *new* local reference to `obj` in the current frame via a `NewLocalRef` JNI call.
+    pub(crate) fn new(env: EnvPtr<'jvm>, obj: &T) -> Self {
+        // SAFETY: The JavaObject trait contract ensures that &T points to a Java object that is an instance of T.
+        unsafe {
+            let new_ref = env.invoke(
+                |jni| jni.NewLocalRef,
+                |jni, f| f(jni, obj.as_raw().as_ptr()),
+            );
+            Self::from_raw(env, NonNull::new(new_ref).unwrap().into())
+        }
+    }
+}
+
+impl<T: JavaObject> Drop for Local<'_, T> {
+    fn drop(&mut self) {
+        // SAFETY: Local owns the local ref and it's no longer possible to dereference the object pointer.
+        unsafe {
+            self.env
+                .invoke(|jni| jni.DeleteLocalRef, |jni, f| f(jni, self.obj.as_ptr()));
+        }
+    }
+}
+
+impl<T: JavaObject> Deref for Local<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: from the guarantees of Local::from_raw, we know obj is a live local ref to an instance of T
+        unsafe { T::from_raw(self.obj) }
+    }
+}
+
+/// An owned global reference to a non-null Java object of type `T`. The reference will be freed when dropped.
+pub struct Global<T: JavaObject> {
+    jvm: JvmPtr,
+    obj: ObjectPtr,
+    _marker: PhantomData<T>,
+}
+
+impl<T: JavaObject> Global<T> {
+    /// Convert an existing global reference pointed to by `obj` into an owned `Global`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `obj` points to a Java object that is an instance of `T` (or its subclasses), is a
+    /// a live, global reference, will not later be deleted (including through another call to `from_raw()`), and will
+    /// not dereferenced after the returned [`Global`] is dropped.
+    pub(crate) unsafe fn from_raw(jvm: JvmPtr, obj: ObjectPtr) -> Self {
+        Self {
+            jvm,
+            obj,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a *new* global reference to `obj` in the current frame via a `NewGlobalRef` JNI call.
+    pub(crate) fn new(jvm: JvmPtr, env: EnvPtr<'_>, obj: &T) -> Self {
+        // SAFETY: The JavaObject trait contract ensures that &T points to a Java object that is an instance of T.
+        unsafe {
+            let new_ref = env.invoke(|e| e.NewGlobalRef, |e, f| f(e, obj.as_raw().as_ptr()));
+            Self::from_raw(jvm, NonNull::new(new_ref).unwrap().into())
+        }
+    }
+}
+
+impl<T: JavaObject> Drop for Global<T> {
+    fn drop(&mut self) {
+        // SAFETY: Global owns the global ref and it's no longer possible to dereference the object pointer.
+        let delete = |env: EnvPtr<'_>| unsafe {
+            env.invoke(
+                |jni| jni.DeleteGlobalRef,
+                |jni, f| f(jni, self.obj.as_ptr()),
+            )
+        };
+
+        match unsafe { self.jvm.env() } {
+            Ok(Some(env)) => delete(env),
+            Ok(None) => {
+                // SAFETY: jvm is a valid pointer since duchess will not deinitialize a JVM once created
+                match unsafe { thread::attach(self.jvm) } {
+                    Ok(mut attached) => delete(attached.env()),
+                    Err(err) => {
+                        tracing::warn!(?err, "unable to attach current thread to delete global ref")
+                    }
+                }
+            }
+            Err(err) => tracing::warn!(
+                ?err,
+                "unable to get JNI interface for local thread to delete global ref"
+            ),
+        }
+    }
+}
+
+// SAFETY: The JNI promises only global refs are shareable across threads
+unsafe impl<T: JavaObject> Send for Global<T> {}
+unsafe impl<T: JavaObject> Sync for Global<T> {}
+
+impl<T: JavaObject> Deref for Global<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: from the guarantees of Global::from_raw, we know obj is a live global ref to an instance of T
+        unsafe { T::from_raw(self.obj) }
+    }
+}
+
+impl<'a, R, S> AsRef<S> for Local<'a, R>
+where
+    R: Upcast<S>,
+    S: JavaObject + 'a,
+{
+    fn as_ref(&self) -> &S {
+        // SAFETY: From the Upcast trait contract, we know R is also an instance of S
+        unsafe { S::from_raw(self.obj) }
+    }
+}
+
+impl<'a, R: JavaObject> Local<'a, R> {
+    pub fn upcast<S>(self) -> Local<'a, S>
+    where
+        R: Upcast<S>,
+        S: JavaObject + 'a,
+    {
+        // SAFETY: From the Upcast trait contract, we know R is also an instance of S
+        let upcast = unsafe { Local::<S>::from_raw(self.env, self.obj) };
+        upcast
+    }
+}
+
+impl<R, S> AsRef<S> for Global<R>
+where
+    R: Upcast<S>,
+    S: JavaObject + 'static,
+{
+    fn as_ref(&self) -> &S {
+        // SAFETY: From the Upcast trait contract, we know R is also an instance of S
+        unsafe { S::from_raw(self.obj) }
+    }
+}
+
+impl<R: JavaObject> Global<R> {
+    pub fn upcast<S>(self) -> Global<S>
+    where
+        R: Upcast<S>,
+        S: JavaObject + 'static,
+    {
+        // SAFETY: From the Upcast trait contract, we know R is also an instance of S
+        let upcast = unsafe { Global::<S>::from_raw(self.jvm, self.obj) };
+        upcast
+    }
+}
+
+impl<'jvm, T> CloneIn<'jvm> for Local<'jvm, T>
+where
+    T: JavaObject,
+{
+    fn clone_in(&self, jvm: &mut Jvm<'jvm>) -> Self {
+        jvm.local(self)
+    }
+}
+
+impl<'jvm, T> CloneIn<'jvm> for Global<T>
+where
+    T: JavaObject,
+{
+    fn clone_in(&self, jvm: &mut Jvm<'jvm>) -> Self {
+        jvm.global(self)
+    }
+}

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,61 +1,33 @@
-use jni::{
-    objects::{AutoLocal, JObject, JString},
-    strings::JNIString,
-};
+use std::ffi::CString;
 
 use crate::{
+    error::check_exception,
     java::lang::String as JavaString,
     jvm::JavaObjectExt,
     ops::{IntoJava, IntoRust},
-    plumbing::with_jni_env,
-    Jvm, JvmOp, Local,
+    plumbing::HasEnvPtr,
+    raw::ObjectPtr,
+    Error, Jvm, JvmOp, Local,
 };
-
-pub trait ToJavaStringOp: JvmOp + Sized {
-    fn to_java_string(self) -> JavaStringOp<Self>;
-}
-
-impl<J: JvmOp> ToJavaStringOp for J
-where
-    for<'jvm> J::Output<'jvm>: Into<JNIString>,
-{
-    fn to_java_string(self) -> JavaStringOp<Self> {
-        JavaStringOp { op: self }
-    }
-}
-
-#[derive(Clone)]
-pub struct JavaStringOp<J: JvmOp> {
-    op: J,
-}
-
-impl<J: JvmOp> JvmOp for JavaStringOp<J>
-where
-    for<'jvm> J::Output<'jvm>: Into<JNIString>,
-{
-    type Input<'jvm> = J::Input<'jvm>;
-    type Output<'jvm> = Local<'jvm, JavaString>;
-
-    fn execute_with<'jvm>(
-        self,
-        jvm: &mut Jvm<'jvm>,
-        input: Self::Input<'jvm>,
-    ) -> crate::Result<'jvm, Self::Output<'jvm>> {
-        let data = self.op.execute_with(jvm, input)?;
-        let env = jvm.to_env();
-        let o = with_jni_env(env, |env| env.new_string(data))?;
-        let o: JObject = o.into();
-        unsafe { Ok(Local::from_jni(AutoLocal::new(o, &env))) }
-    }
-}
 
 impl IntoJava<JavaString> for &str {
     type Output<'jvm> = Local<'jvm, JavaString>;
 
     fn into_java<'jvm>(self, jvm: &mut Jvm<'jvm>) -> crate::Result<'jvm, Local<'jvm, JavaString>> {
-        let env = jvm.to_env();
-        let string = with_jni_env(env, |env| env.new_string(self))?;
-        unsafe { Ok(Local::from_jni(AutoLocal::new(JObject::from(string), &env))) }
+        let encoded = cesu8::to_java_cesu8(self);
+        // SAFETY: cesu8 encodes interior nul bytes as 0xC080
+        let c_string = unsafe { CString::from_vec_unchecked(encoded.into_owned()) };
+
+        let env = jvm.env();
+        // SAFETY: c_string is non-null pointer to cesu8-encoded encoded string ending in a trailing nul byte
+        let string =
+            unsafe { env.invoke(|env| env.NewStringUTF, |env, f| f(env, c_string.as_ptr())) };
+        if let Some(string) = ObjectPtr::new(string) {
+            Ok(unsafe { Local::from_raw(env, string) })
+        } else {
+            check_exception(jvm)?; // likely threw an OutOfMemoryError
+            Err(Error::JvmInternal("JVM failed to create new String".into()))
+        }
     }
 }
 
@@ -73,13 +45,64 @@ where
     for<'jvm> J::Output<'jvm>: AsRef<JavaString>,
 {
     fn into_rust<'jvm>(self, jvm: &mut Jvm<'jvm>) -> crate::Result<'jvm, String> {
-        let object = self.execute_with(jvm, ())?;
-        let env = jvm.to_env();
-        // XX: safety? is this the right way to do this cast?
-        let string_object = unsafe { JString::from_raw(object.as_ref().as_jobject().as_raw()) };
-        let string = with_jni_env(env, |env| unsafe {
-            env.get_string_unchecked(&string_object)
-        })?;
-        Ok(string.into())
+        let output = self.execute_with(jvm, ())?;
+        let str_raw = output.as_ref().as_raw();
+
+        let env = jvm.env();
+
+        // Note: we need to pull both the Modified UTF-8 length and the UTF-16 length of the string. The indexes to
+        // GetStringUTFRegion are UTF-16, while the space we need to allocate for the output pointer is the Modified
+        // UTF-8 length!
+
+        // SAFETY: J::Output impls AsRef<JavaString>, so we know str_raw points to a non-null Java String
+        let cesu8_len = unsafe {
+            env.invoke(
+                |env| env.GetStringUTFLength,
+                |env, f| f(env, str_raw.as_ptr()),
+            )
+        };
+        assert!(cesu8_len >= 0);
+
+        // SAFETY: same as for cesu8_len
+        let utf16_len =
+            unsafe { env.invoke(|env| env.GetStringLength, |env, f| f(env, str_raw.as_ptr())) };
+        assert!(utf16_len >= 0);
+
+        let mut cesu_bytes = Vec::<u8>::with_capacity(cesu8_len as usize);
+        // SAFETY: cesu_bytes is a non-null pointer with enough capacity for the entire string when encoded in Modified
+        // UTF-8 (with no trailing nul byte).
+        unsafe {
+            env.invoke(
+                |env| env.GetStringUTFRegion,
+                |env, f| {
+                    f(
+                        env,
+                        str_raw.as_ptr(),
+                        0,
+                        utf16_len,
+                        cesu_bytes.as_mut_ptr().cast::<i8>(),
+                    )
+                },
+            );
+            cesu_bytes.set_len(cesu8_len as usize);
+        };
+        check_exception(jvm)?;
+
+        // In the common case where there are no surrogate bytes, we can do a (checked) conversion of the Vec into a
+        // Rust String. Otherwise, we'll need to use the cesu8 crate to convert properly. Note that this is the same
+        // first check done by cesu8, but because the interface takes an &[u8], it would force a copy.
+        let decoded = match String::from_utf8(cesu_bytes) {
+            Ok(s) => s,
+            Err(err) => cesu8::from_java_cesu8(err.as_bytes())
+                .map_err(|e| {
+                    Error::JvmInternal(format!(
+                        "Java String contained invalid Modified UTF-8: {}",
+                        e
+                    ))
+                })?
+                .into_owned(),
+        };
+
+        Ok(decoded)
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,0 +1,93 @@
+use std::cell::Cell;
+
+use crate::{
+    raw::{EnvPtr, JvmPtr},
+    Error, GlobalResult,
+};
+
+// XX: The current thread-local state will prevent duchess => java => duchess call stacks. We may want to relax this in
+// the future!
+thread_local! {
+    static STATE: Cell<State> = Cell::new(State::Detached);
+}
+
+enum State {
+    /// The JVM is attached to the current thread, but we're already inside a duchess frame.
+    InUse,
+    /// The JVM is permanently attached to the current thread, but we're not inside a duchess frame.
+    AttachedPermanently(EnvPtr<'static>),
+    /// Duchess thinks the JVM is detached, though JNI calls through other means could change this.
+    Detached,
+}
+
+fn attached_or(
+    jvm: JvmPtr,
+    f: impl FnOnce() -> GlobalResult<AttachGuard>,
+) -> GlobalResult<AttachGuard> {
+    STATE.with(|state| match state.replace(State::InUse) {
+        State::AttachedPermanently(env) => Ok(AttachGuard {
+            jvm,
+            env,
+            permanent: true,
+        }),
+        State::InUse => Err(Error::NestedUsage),
+        State::Detached => {
+            let result = f();
+            if result.is_err() {
+                state.set(State::Detached);
+            }
+            result
+        }
+    })
+}
+
+pub fn attach_permanently(jvm: JvmPtr) -> GlobalResult<AttachGuard> {
+    attached_or(jvm, || {
+        Ok(AttachGuard {
+            jvm,
+            // no-op if already attached outside of duchess
+            env: unsafe { jvm.attach_thread()? },
+            permanent: true,
+        })
+    })
+}
+
+pub unsafe fn attach<'jvm>(jvm: JvmPtr) -> GlobalResult<AttachGuard> {
+    attached_or(jvm, || {
+        Ok(AttachGuard {
+            jvm,
+            // no-op if already attached outside of duchess
+            env: unsafe { jvm.attach_thread()? },
+            permanent: false,
+        })
+    })
+}
+
+/// When dropped, will detach the current thread from the JVM unless it was permanently attached.
+pub struct AttachGuard {
+    jvm: JvmPtr,
+    env: EnvPtr<'static>, // not send!
+    permanent: bool,
+}
+
+impl Drop for AttachGuard {
+    fn drop(&mut self) {
+        if self.permanent {
+            STATE.with(|state| {
+                let old_state = state.replace(State::AttachedPermanently(self.env));
+                debug_assert!(matches!(old_state, State::InUse))
+            });
+        } else {
+            match unsafe { self.jvm.detach_thread() } {
+                Ok(()) => STATE.with(|state| state.set(State::Detached)),
+                Err(err) => tracing::warn!(?err, "couldn't detach thread from JVM"),
+            }
+        }
+    }
+}
+
+impl AttachGuard {
+    pub fn env(&mut self) -> EnvPtr<'_> {
+        self.env
+    }
+}

--- a/test-crates/viper/build.rs
+++ b/test-crates/viper/build.rs
@@ -1,6 +1,7 @@
-use std::{env, io, fs, path};
+use std::{env, fs, io, path};
 
-static JAR_URL: &str = "https://github.com/viperproject/viperserver/releases/download/v.23.01-release/viperserver.jar";
+static JAR_URL: &str =
+    "https://github.com/viperproject/viperserver/releases/download/v.23.01-release/viperserver.jar";
 
 fn main() {
     let out_dir_string = env::var("OUT_DIR").unwrap();

--- a/test-crates/viper/tests/test.rs
+++ b/test-crates/viper/tests/test.rs
@@ -4,8 +4,7 @@ use std::sync::Once;
 static INIT: Once = Once::new();
 
 fn setup_tests() {
-    let classpath = std::env::var("CLASSPATH").unwrap();
-    duchess::Jvm::builder().add_classpath(classpath).launch(|_jvm| Ok(())).unwrap();
+    duchess::Jvm::builder().try_launch().unwrap();
 }
 
 #[test]

--- a/tests/bad_jvm_construction_1.rs
+++ b/tests/bad_jvm_construction_1.rs
@@ -3,6 +3,6 @@ use duchess::Jvm;
 #[test]
 fn test_jvm_construction_error() {
     Jvm::with(|_jvm| Ok(())).unwrap();
-    let res = Jvm::builder().launch(|_jvm| Ok(()));
-    assert!(res.is_err());
+    let res = Jvm::builder().try_launch();
+    assert!(matches!(res, Err(duchess::Error::JvmAlreadyExists)));
 }

--- a/tests/bad_jvm_construction_1.rs
+++ b/tests/bad_jvm_construction_1.rs
@@ -2,11 +2,11 @@ use duchess::Jvm;
 
 #[test]
 fn test_jvm_construction_error() {
-    println!("using default");
+    eprintln!("using default");
     Jvm::with(|_jvm| Ok(())).unwrap();
-    println!("trying to build our own");
+    eprintln!("trying to build our own");
     let res = Jvm::builder().try_launch();
-    println!("built our own");
+    eprintln!("built our own");
     assert!(matches!(res, Err(duchess::Error::JvmAlreadyExists)));
-    println!("exiting");
+    eprintln!("exiting");
 }

--- a/tests/bad_jvm_construction_1.rs
+++ b/tests/bad_jvm_construction_1.rs
@@ -4,9 +4,6 @@ use duchess::Jvm;
 fn test_jvm_construction_error() {
     eprintln!("using default");
     Jvm::with(|_jvm| Ok(())).unwrap();
-    eprintln!("trying to build our own");
     let res = Jvm::builder().try_launch();
-    eprintln!("built our own");
     assert!(matches!(res, Err(duchess::Error::JvmAlreadyExists)));
-    eprintln!("exiting");
 }

--- a/tests/bad_jvm_construction_1.rs
+++ b/tests/bad_jvm_construction_1.rs
@@ -2,7 +2,11 @@ use duchess::Jvm;
 
 #[test]
 fn test_jvm_construction_error() {
+    println!("using default");
     Jvm::with(|_jvm| Ok(())).unwrap();
+    println!("trying to build our own");
     let res = Jvm::builder().try_launch();
+    println!("built our own");
     assert!(matches!(res, Err(duchess::Error::JvmAlreadyExists)));
+    println!("exiting");
 }

--- a/tests/bad_jvm_construction_1.rs
+++ b/tests/bad_jvm_construction_1.rs
@@ -2,7 +2,6 @@ use duchess::Jvm;
 
 #[test]
 fn test_jvm_construction_error() {
-    eprintln!("using default");
     Jvm::with(|_jvm| Ok(())).unwrap();
     let res = Jvm::builder().try_launch();
     assert!(matches!(res, Err(duchess::Error::JvmAlreadyExists)));

--- a/tests/bad_jvm_construction_2.rs
+++ b/tests/bad_jvm_construction_2.rs
@@ -2,7 +2,7 @@ use duchess::Jvm;
 
 #[test]
 fn test_jvm_construction_error() {
-    Jvm::builder().launch(|_jvm| Ok(())).unwrap();
-    let res = Jvm::builder().launch(|_jvm| Ok(()));
-    assert!(res.is_err());
+    Jvm::builder().try_launch().unwrap();
+    let res = Jvm::builder().try_launch();
+    assert!(matches!(res, Err(duchess::Error::JvmAlreadyExists)));
 }

--- a/tests/good_jvm_construction_2.rs
+++ b/tests/good_jvm_construction_2.rs
@@ -2,7 +2,7 @@ use duchess::Jvm;
 
 #[test]
 fn test_jvm_construction() {
-    Jvm::builder().launch(|_jvm| Ok(())).unwrap();
+    Jvm::builder().try_launch().unwrap();
     Jvm::with(|_jvm| Ok(())).unwrap();
     Jvm::with(|_jvm| Ok(())).unwrap();
 }


### PR DESCRIPTION
The `jni` crate provides a thin wrapper on top of the `jni-sys` headers and we were often writing more complicated code to use it instead of making direct `jni-sys` calls. It also gives us more flexibility around exception handling, `libjvm` linking, and users brining their own JVM instance.

The `raw` mod now contains most of the newtype wrappers we need around `jni-sys` pointers.

This commit adds an optional `dylibjvm` feature that gives the same dynamic linking behavior as the `jni` crate. Without it, it expects `libjvm` to be statically linked. It also adds a friendly thrown-error message.

Some of the initialization and string-passing code should be marginally faster since we avoid some copies into and out of cesu8 and c encodings.