### PR TITLE
Fix race condition in JVM creation

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -19,7 +19,11 @@ const VERSION: jni_sys::jint = jni_sys::JNI_VERSION_1_8;
 /// Get a [`JvmPtr`] to an already initialized JVM (if one exists).
 ///
 /// If the `dynlibjvm` feature is enabled and `libjvm` isn't already loaded, it will first force it to be loaded.
-pub(crate) fn jvm() -> GlobalResult<Option<JvmPtr>> {
+///
+/// # Safety
+///
+/// Caller must ensure that no two threads race to call this fn or [`try_create_jvm()`].
+pub(crate) unsafe fn existing_jvm() -> GlobalResult<Option<JvmPtr>> {
     let libjvm = crate::libjvm::libjvm_or_load()?;
 
     let mut jvms = [std::ptr::null_mut::<jni_sys::JavaVM>()];
@@ -53,7 +57,11 @@ pub(crate) fn jvm() -> GlobalResult<Option<JvmPtr>> {
 /// [`Error::JvmAlreadyExists`] if one already exists.
 ///
 /// If the `dynlibjvm` feature is enabled and `libjvm` isn't already loaded, it will first force it to be loaded.
-pub(crate) fn try_create_jvm<'a>(
+///
+/// # Safety
+///
+/// Caller must ensure that no two threads race to call this fn or [`jvm()`].
+pub(crate) unsafe fn try_create_jvm<'a>(
     options: impl IntoIterator<Item = String>,
 ) -> GlobalResult<JvmPtr> {
     let libjvm = crate::libjvm::libjvm_or_load()?;

--- a/tests/racing_jvm_construction.rs
+++ b/tests/racing_jvm_construction.rs
@@ -1,0 +1,17 @@
+use duchess::Jvm;
+use std::{sync, thread};
+
+#[test]
+fn race_multiple_threads_to_launch_jvm() {
+    let n = 10;
+    let barrier = sync::Arc::new(sync::Barrier::new(10));
+    thread::scope(|scope| {
+        for _ in 0..n {
+            let barrier = sync::Arc::clone(&barrier);
+            scope.spawn(move || {
+                barrier.wait();
+                Jvm::with(|_jvm| Ok(())).unwrap();
+            });
+        }
+    });
+}


### PR DESCRIPTION
Fixes a race condition when multiple threads try to create or look up existing JVMs at the same time by sequencing the calls behind the `GLOBAL_JVM` sync cell.

Marked the raw fns as `unsafe` and added a test case for regression. Test is a bit racy without the fix (may panic or segfault depending on sequencing), but confirmed we get
```
process didn't exit successfully: `... race_multiple_threads_to_launch_jvm --exact --nocapture` (signal: 11, SIGSEGV: invalid memory reference)
```
without the fix and ok with it.