### PR TITLE
Improvements to use Scala's companion objects

### DIFF
--- a/macro/src/class_info/javap_parser.lalrpop
+++ b/macro/src/class_info/javap_parser.lalrpop
@@ -42,8 +42,9 @@ ClassInfoInline: ClassInfo = {
         let mut methods = vec![];
         for member in m.into_iter() {
             match member {
-                MemberFunction::Constructor(c) => constructors.push(c),
-                MemberFunction::Method(m) => methods.push(m),
+                Some(MemberFunction::Constructor(c)) => constructors.push(c),
+                Some(MemberFunction::Method(m)) => methods.push(m),
+                None => {}
             }
         }
         ClassInfo {
@@ -86,7 +87,7 @@ GenericBounds: Vec<ClassRef> = {
     },
 };
 
-Header: () = r#"Compiled from "[a-zA-Z$0-9_.]+""#;
+Header: () = r#"Compiled from "[a-zA-Z0-9_$. ]+""#;
 
 DotId: DotId = {
     <a:Id> "." <b:ID> => a.dot(b),
@@ -98,12 +99,14 @@ Id: Id = {
 };
 
 ID: &'input str = {
-    r"[a-zA-Z_$][a-zA-Z$0-9_]*"
+    <r"[a-zA-Z_$][a-zA-Z0-9_$]*">,
+    "\"" <r"[a-zA-Z_$][a-zA-Z0-9_$]*"> "\"",
 }
 
-MemberFunction: MemberFunction = {
-    <c:Constructor> => MemberFunction::Constructor(c),
-    <m:Method> => MemberFunction::Method(m),
+MemberFunction: Option<MemberFunction> = {
+    <c:Constructor> => Some(MemberFunction::Constructor(c)),
+    <m:Method> => Some(MemberFunction::Method(m)),
+    <i:Initializator> => None,
 }
 
 Constructor: Constructor = {
@@ -122,6 +125,10 @@ Method: Method = {
     <f:Flags> <g:Generics> <r:ReturnType> <n:Id> "(" <a:Comma<Type>> ")" <t:Throws> ";" => {
         Method { flags: f, name: n, argument_tys: a, return_ty: r, throws: t, generics: g }
     }
+};
+
+Initializator: () = {
+    <Flags> "{" "}" ";" => ()
 };
 
 Field: Field = {

--- a/macro/src/class_info/javap_parser.lalrpop
+++ b/macro/src/class_info/javap_parser.lalrpop
@@ -90,8 +90,8 @@ GenericBounds: Vec<ClassRef> = {
 Header: () = r#"Compiled from "[a-zA-Z0-9_$. ]+""#;
 
 DotId: DotId = {
-    <a:Id> "." <b:ID> => a.dot(b),
-    <i:DotId> "." <s:ID> => i.dot(s),
+    <a:Id> r"[./]" <b:ID> => a.dot(b),
+    <i:DotId> r"[./]" <s:ID> => i.dot(s),
 };
 
 Id: Id = {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -728,13 +728,13 @@ impl ClassInfo {
     }
 
     fn struct_name(&self) -> Ident {
-        let tail = self.name.class_name();
-        Ident::new(&tail, self.span)
+        self.name.class_name().to_ident(self.span)
     }
 
     fn ext_trait_name(&self) -> Ident {
-        let tail = self.name.class_name();
-        Ident::new(&format!("{tail}Ext"), self.span)
+        let mut id = self.name.class_name().clone();
+        id.data.push_str("Ext");
+        id.to_ident(self.span)
     }
 
     fn class_generic_names(&self) -> Vec<Ident> {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -1093,60 +1093,6 @@ impl Signature {
         Ok(Ident::new(f, self.span))
     }
 
-    // Currently unused
-    fn _jni_field_get_fn(&mut self, ty: &Type) -> Result<Ident, SpanError> {
-        let f = match ty {
-            Type::Ref(_) => "GetObjectField",
-            Type::Repeat(_) => {
-                return Err(SpanError {
-                    span: self.span,
-                    message: format!(
-                        "unsupported repeating type in getter of field `{}`",
-                        self.item_name
-                    ),
-                })
-            }
-            Type::Scalar(scalar) => match scalar {
-                ScalarType::Int => "GetIntField",
-                ScalarType::Long => "GetLongField",
-                ScalarType::Short => "GetShortField",
-                ScalarType::Byte => "GetByteField",
-                ScalarType::F64 => "GetDoubleField",
-                ScalarType::F32 => "GetFloatField",
-                ScalarType::Boolean => "GetBooleanField",
-                ScalarType::Char => "GetCharField",
-            },
-        };
-        Ok(Ident::new(f, self.span))
-    }
-
-    // Currently unused
-    fn _jni_field_set_fn(&mut self, ty: &Type) -> Result<Ident, SpanError> {
-        let f = match ty {
-            Type::Ref(_) => "SetObjectField",
-            Type::Repeat(_) => {
-                return Err(SpanError {
-                    span: self.span,
-                    message: format!(
-                        "unsupported repeating type in setter of field `{}`",
-                        self.item_name
-                    ),
-                })
-            }
-            Type::Scalar(scalar) => match scalar {
-                ScalarType::Int => "SetIntField",
-                ScalarType::Long => "SetLongField",
-                ScalarType::Short => "SetShortField",
-                ScalarType::Byte => "SetByteField",
-                ScalarType::F64 => "SetDoubleField",
-                ScalarType::F32 => "SetFloatField",
-                ScalarType::Boolean => "SetBooleanField",
-                ScalarType::Char => "SetCharField",
-            },
-        };
-        Ok(Ident::new(f, self.span))
-    }
-
     fn jni_static_field_get_fn(&mut self, ty: &Type) -> Result<Ident, SpanError> {
         let f = match ty {
             Type::Ref(_) => "GetStaticObjectField",
@@ -1168,33 +1114,6 @@ impl Signature {
                 ScalarType::F32 => "GetStaticFloatField",
                 ScalarType::Boolean => "GetStaticBooleanField",
                 ScalarType::Char => "GetStaticCharField",
-            },
-        };
-        Ok(Ident::new(f, self.span))
-    }
-
-    // Currently unused
-    fn _jni_static_field_set_fn(&mut self, ty: &Type) -> Result<Ident, SpanError> {
-        let f = match ty {
-            Type::Ref(_) => "SetStaticObjectField",
-            Type::Repeat(_) => {
-                return Err(SpanError {
-                    span: self.span,
-                    message: format!(
-                        "unsupported repeating type in setter of static field `{}`",
-                        self.item_name
-                    ),
-                })
-            }
-            Type::Scalar(scalar) => match scalar {
-                ScalarType::Int => "SetStaticIntField",
-                ScalarType::Long => "SetStaticLongField",
-                ScalarType::Short => "SetStaticShortField",
-                ScalarType::Byte => "SetStaticByteField",
-                ScalarType::F64 => "SetStaticDoubleField",
-                ScalarType::F32 => "SetStaticFloatField",
-                ScalarType::Boolean => "SetStaticBooleanField",
-                ScalarType::Char => "SetStaticCharField",
             },
         };
         Ok(Ident::new(f, self.span))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub mod prelude {
     pub use crate::cast::by_type;
     pub use crate::jvm::JvmOp;
     pub use crate::ops::{
-        IntoJava, IntoLocal, IntoOptLocal, IntoScalar, IntoVoid, JavaMethod, ScalarMethod,
-        VoidMethod,
+        IntoJava, IntoLocal, IntoOptLocal, IntoScalar, IntoVoid, JavaField, JavaMethod, ScalarField,
+        ScalarMethod, VoidMethod,
     };
     pub use crate::to_java::ToJava;
 }
@@ -54,9 +54,9 @@ pub mod prelude {
 pub mod plumbing {
     pub use crate::cast::Upcast;
     pub use crate::error::check_exception;
-    pub use crate::find::{find_class, find_constructor, find_method};
+    pub use crate::find::{find_class, find_constructor, find_field, find_method};
     pub use crate::global::GlobalOp;
     pub use crate::jvm::JavaObjectExt;
     pub use crate::refs::NullJRef;
-    pub use crate::raw::{FromJniValue, HasEnvPtr, IntoJniValue, MethodPtr, ObjectPtr};
+    pub use crate::raw::{FieldPtr, FromJniValue, HasEnvPtr, IntoJniValue, MethodPtr, ObjectPtr};
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -157,3 +157,33 @@ where
 }
 
 impl<J> VoidMethod for J where for<'jvm> Self: JvmOp<Output<'jvm> = ()> {}
+
+/// A java field that returns a `T` object (when executed).
+pub trait JavaField<T>
+where
+    T: JavaObject,
+    for<'jvm> Self: JvmOp<Output<'jvm> = Option<Local<'jvm, T>>>,
+{
+}
+
+impl<J, T> JavaField<T> for J
+where
+    T: JavaObject,
+    for<'jvm> Self: JvmOp<Output<'jvm> = Option<Local<'jvm, T>>>,
+{
+}
+
+/// A java field that returns a scalar value of type `T` when executed.
+pub trait ScalarField<T>
+where
+    T: JavaScalar,
+    for<'jvm> Self: JvmOp<Output<'jvm> = T>,
+{
+}
+
+impl<J, T> ScalarField<T> for J
+where
+    T: JavaScalar,
+    for<'jvm> Self: JvmOp<Output<'jvm> = T>,
+{
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -310,6 +310,25 @@ impl MethodPtr {
 unsafe impl Send for MethodPtr {}
 unsafe impl Sync for MethodPtr {}
 
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct FieldPtr(NonNull<jni_sys::_jfieldID>);
+
+impl FieldPtr {
+    pub(crate) fn new(ptr: jni_sys::jfieldID) -> Option<Self> {
+        NonNull::new(ptr).map(Self)
+    }
+
+    #[doc(hidden)]
+    pub fn as_ptr(self) -> jni_sys::jfieldID {
+        self.0.as_ptr()
+    }
+}
+
+// The JNI promises method pointers remain valid for as long as the class is loaded and can be shared across threads
+unsafe impl Send for FieldPtr {}
+unsafe impl Sync for FieldPtr {}
+
 /// Trait used by codegen to convert into [`jni-sys`] unions.
 #[doc(hidden)]
 pub trait IntoJniValue {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -325,7 +325,7 @@ impl FieldPtr {
     }
 }
 
-// The JNI promises method pointers remain valid for as long as the class is loaded and can be shared across threads
+// The JNI promises field pointers remain valid for as long as the class is loaded and can be shared across threads
 unsafe impl Send for FieldPtr {}
 unsafe impl Sync for FieldPtr {}
 

--- a/test-crates/viper/src/lib.rs
+++ b/test-crates/viper/src/lib.rs
@@ -1,11 +1,29 @@
 duchess::java_package! {
+    package java.lang;
+    class Object {}
+
     package scala;
     class AnyVal { * }
     class Function1 {}
     class Tuple2<T1, T2> {}
 
+    package scala.collection;
+    interface IterableOnceOps<A, CC, C> {
+        default scala.collection.immutable.Seq<A> toSeq();
+    }
+    interface IterableOps<A, CC, C> extends scala.collection.IterableOnceOps<A, CC, C> {}
+    interface SeqOps<A, CC, C> extends scala.collection.IterableOps<A, CC, C> {}
+    interface StrictOptimizedSeqOps<A, CC, C> extends scala.collection.SeqOps<A, CC, C> {}
+
     package scala.collection.immutable;
     interface Seq<A> {}
+
+    package scala.collection.mutable;
+    class ArrayBuffer<A>
+        implements scala.collection.StrictOptimizedSeqOps<A, scala.collection.mutable.ArrayBuffer, scala.collection.mutable.ArrayBuffer<A>>
+    {
+        scala.collection.mutable.ArrayBuffer();
+    }
 
     package viper.silver.ast;
     class Bool {}
@@ -16,7 +34,7 @@ duchess::java_package! {
 
     package viper.silver.reporter;
     interface Reporter {}
-    class "NoopReporter$" {
+    class "NoopReporter$" implements viper.silver.reporter.Reporter {
         static viper.silver.reporter."NoopReporter$" "MODULE$";
     }
 

--- a/test-crates/viper/src/lib.rs
+++ b/test-crates/viper/src/lib.rs
@@ -19,15 +19,46 @@ duchess::java_package! {
     interface Seq<A> {}
 
     package scala.collection.mutable;
-    class ArrayBuffer<A>
-        implements scala.collection.StrictOptimizedSeqOps<A, scala.collection.mutable.ArrayBuffer, scala.collection.mutable.ArrayBuffer<A>>
-    {
+    class ArrayBuffer<A> implements scala.collection.StrictOptimizedSeqOps<
+        A, scala.collection.mutable.ArrayBuffer, scala.collection.mutable.ArrayBuffer<A>
+    > {
         scala.collection.mutable.ArrayBuffer();
     }
 
     package viper.silver.ast;
     class Bool {}
+    class Domain {}
+    class "NoTrafos$" implements viper.silver.ast.ErrorTrafo {
+        static viper.silver.ast."NoTrafos$" "MODULE$";
+    }
+    class ExtensionMember {}
+    class Field {}
+    class Function {}
     class Int {}
+    class Method {}
+    class "NoPosition$" implements viper.silver.ast.Position {
+        static viper.silver.ast."NoPosition$" "MODULE$";
+    }
+    class "NoInfo$" implements viper.silver.ast.Info {
+        static viper.silver.ast."NoInfo$" "MODULE$";
+    }
+    class Predicate {}
+    class Program {
+        public viper.silver.ast.Program(
+            scala.collection.immutable.Seq<viper.silver.ast.Domain>,
+            scala.collection.immutable.Seq<viper.silver.ast.Field>,
+            scala.collection.immutable.Seq<viper.silver.ast.Function>,
+            scala.collection.immutable.Seq<viper.silver.ast.Predicate>,
+            scala.collection.immutable.Seq<viper.silver.ast.Method>,
+            scala.collection.immutable.Seq<viper.silver.ast.ExtensionMember>,
+            viper.silver.ast.Position,
+            viper.silver.ast.Info,
+            viper.silver.ast.ErrorTrafo
+        );
+    }
+    interface ErrorTrafo {}
+    interface Info {}
+    interface Position {}
 
     package viper.silver.frontend;
     class SilFrontend {}
@@ -45,6 +76,9 @@ duchess::java_package! {
 
     package viper.carbon;
     class CarbonVerifier {
-        viper.carbon.CarbonVerifier(viper.silver.reporter.Reporter, scala.collection.immutable.Seq<scala.Tuple2<java.lang.String, java.lang.Object>>);
+        viper.carbon.CarbonVerifier(
+            viper.silver.reporter.Reporter,
+            scala.collection.immutable.Seq<scala.Tuple2<java.lang.String, java.lang.Object>>
+        );
     }
 }

--- a/test-crates/viper/src/lib.rs
+++ b/test-crates/viper/src/lib.rs
@@ -16,6 +16,9 @@ duchess::java_package! {
 
     package viper.silver.reporter;
     interface Reporter {}
+    class "NoopReporter$" {
+        static viper.silver.reporter."NoopReporter$" "MODULE$";
+    }
 
     package viper.silicon;
     class Silicon {

--- a/test-crates/viper/tests/test.rs
+++ b/test-crates/viper/tests/test.rs
@@ -1,18 +1,29 @@
 use duchess::prelude::*;
-use std::sync::Once;
+use duchess::java::lang::{Object, String};
+use viper::viper::silicon::Silicon;
+use viper::viper::carbon::CarbonVerifier;
+use viper::viper::silver::reporter::NoopReporter__;
+use viper::scala::Tuple2;
+use viper::scala::collection::{IterableOnceOps, IterableOnceOpsExt};
+use viper::scala::collection::IterableOps;
+use viper::scala::collection::SeqOps;
+use viper::scala::collection::StrictOptimizedSeqOps;
+use viper::scala::collection::mutable::ArrayBuffer;
 
-static INIT: Once = Once::new();
-
-fn setup_tests() {
-    duchess::Jvm::builder().try_launch().unwrap();
-}
+type DebugInfoItem = Tuple2<String, Object>;
 
 #[test]
 fn test_construct_silicon() -> duchess::GlobalResult<()> {
-    INIT.call_once(setup_tests);
     duchess::Jvm::with(|jvm| {
-        use viper::viper::silicon::Silicon;
         let _silicon = Silicon::new().execute_with(jvm)?;
+        let reporter = NoopReporter__::get_module();
+        let debug_info = ArrayBuffer::new()
+            .upcast::<StrictOptimizedSeqOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
+            .upcast::<SeqOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
+            .upcast::<IterableOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
+            .upcast::<IterableOnceOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
+            .to_seq();
+        let _carbon = CarbonVerifier::new(reporter, debug_info).execute_with(jvm)?;
         Ok(())
     })
 }

--- a/test-crates/viper/tests/test.rs
+++ b/test-crates/viper/tests/test.rs
@@ -1,29 +1,70 @@
-use duchess::prelude::*;
 use duchess::java::lang::{Object, String};
-use viper::viper::silicon::Silicon;
-use viper::viper::carbon::CarbonVerifier;
-use viper::viper::silver::reporter::NoopReporter__;
-use viper::scala::Tuple2;
-use viper::scala::collection::{IterableOnceOps, IterableOnceOpsExt};
+use duchess::prelude::*;
+use viper::scala::collection::immutable::Seq;
+use viper::scala::collection::mutable::ArrayBuffer;
 use viper::scala::collection::IterableOps;
 use viper::scala::collection::SeqOps;
 use viper::scala::collection::StrictOptimizedSeqOps;
-use viper::scala::collection::mutable::ArrayBuffer;
+use viper::scala::collection::{IterableOnceOps, IterableOnceOpsExt};
+use viper::scala::Tuple2;
+use viper::viper::carbon::CarbonVerifier;
+use viper::viper::silicon::Silicon;
+use viper::viper::silver::ast;
+use viper::viper::silver::reporter::NoopReporter__;
 
-type DebugInfoItem = Tuple2<String, Object>;
+/// Builds an empty Scala Seq of the specified type
+fn empty_scala_seq<T: duchess::JavaObject>() -> impl IntoJava<Seq<T>> {
+    ArrayBuffer::new()
+        .upcast::<StrictOptimizedSeqOps<T, ArrayBuffer, ArrayBuffer<T>>>()
+        .upcast::<SeqOps<T, ArrayBuffer, ArrayBuffer<T>>>()
+        .upcast::<IterableOps<T, ArrayBuffer, ArrayBuffer<T>>>()
+        .upcast::<IterableOnceOps<T, ArrayBuffer, ArrayBuffer<T>>>()
+        .to_seq()
+        .assert_not_null()
+}
 
 #[test]
-fn test_construct_silicon() -> duchess::GlobalResult<()> {
+fn test_program_construction() -> duchess::GlobalResult<()> {
+    duchess::Jvm::with(|jvm| {
+        let domains = empty_scala_seq::<ast::Domain>();
+        let fields = empty_scala_seq::<ast::Field>();
+        let functions = empty_scala_seq::<ast::Function>();
+        let predicates = empty_scala_seq::<ast::Predicate>();
+        let methods = empty_scala_seq::<ast::Method>();
+        let extension_member = empty_scala_seq::<ast::ExtensionMember>();
+        let position = ast::NoPosition__::get_module();
+        let info = ast::NoInfo__::get_module();
+        let error_trafo = ast::NoTrafos__::get_module();
+        let _program = ast::Program::new(
+            domains,
+            fields,
+            functions,
+            predicates,
+            methods,
+            extension_member,
+            position,
+            info,
+            error_trafo,
+        )
+        .execute_with(jvm)?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_carbon_construction() -> duchess::GlobalResult<()> {
+    duchess::Jvm::with(|jvm| {
+        let reporter = NoopReporter__::get_module();
+        let debug_info = empty_scala_seq::<Tuple2<String, Object>>();
+        let _carbon = CarbonVerifier::new(reporter, debug_info).execute_with(jvm)?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_silicon_construction() -> duchess::GlobalResult<()> {
     duchess::Jvm::with(|jvm| {
         let _silicon = Silicon::new().execute_with(jvm)?;
-        let reporter = NoopReporter__::get_module();
-        let debug_info = ArrayBuffer::new()
-            .upcast::<StrictOptimizedSeqOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
-            .upcast::<SeqOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
-            .upcast::<IterableOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
-            .upcast::<IterableOnceOps<DebugInfoItem, ArrayBuffer, ArrayBuffer<DebugInfoItem>>>()
-            .to_seq();
-        let _carbon = CarbonVerifier::new(reporter, debug_info).execute_with(jvm)?;
         Ok(())
     })
 }


### PR DESCRIPTION
General improvements:
* I extended the grammar in order to accept the `throws java/lang/IndexOutOfBoundsException` that `javap` generates, where the class reference uses `/` instead of `.`.
* `javap` outputs `public static {};` for classes with a static initialization block, also called `<clinit>`. I extended the grammar to parse and ignore that, since the initialization block is automatically executed by the JVM when necessary.
* I hit the issue https://github.com/duchess-rs/duchess/issues/41: in `java_package!` I needed to write `ArrayBuffer` but then the compiler was complaining that a type parameter was missing. So, I added a `java::lang::Object` default to *every* generated type parameter.

To support identifiers with `$` (https://github.com/duchess-rs/duchess/issues/12):
* Parsing classes with `$` was not supported in `java_package!`, because of whitespaces introduced when printing a token stream ([relevant comment](https://github.com/duchess-rs/duchess/issues/12#issuecomment-1535951998)). I extended the grammar to support identifiers in quotes. Example:
    ```
    class "NoopReporter$" implements viper.silver.reporter.Reporter {
        static viper.silver.reporter."NoopReporter$" "MODULE$";
    }
    ```
* When generating Rust identifiers, `Id::to_ident` was already replacing `$` with `__`, but that was not done consistently. So, I replaced all the `Ident::new(..)` that I could find with `Id::new(..).to_ident(..)`.

To use static fields:
* I added a `FieldPtr` to `raw.rs` and a `find_field` to `find.rs` (CC @chase-ok)
* I added the generation of `fn get_{field}()` Rust methods to obtain static Java fields.
* Side note: the `codegen.rs` file is getting very big and there are various repetitions (e.g. `static_method`/`object_method`/`static_field_getter`, and `jni_call_fn`/`jni_static_call_fn`/`jni_static_field_get_fn`/...). I didn't investigate how to refactor that.

Testing:
* I added a few tests to `test-crates/viper`. The most annoying part is that to call the inherited `to_seq` method on a Scala's `ArrayBuffer` I had to write ~300 characters of upcasts.