### PR TITLE
Add ui test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,12 @@ java-locator = { version = "0.1.3", optional = true }
 libloading = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
-expect-test = "1.4.1"
+ui_test = "0.10.0"
 
 [features]
 default = ["dylibjvm"]
-dylibjvm = [
-    "java-locator",
-    "libloading",
-]
+dylibjvm = ["java-locator", "libloading"]
+
+[[test]]
+name = "ui"
+harness = false

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You need the `javap` tool on your path.
 On Ubuntu, I installed `java-20-amazon-corretto-jdk/stable`, 
 but `openjdk-17-jre/stable-security` might also work. --nikomatsakis
 
+oli: `openjdk-17-jdk-headless` works on unbuntu.
+
 ## How to use
 
 *This is a README from the future, in that it describes the intended plan for the crate.*

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -21,8 +21,5 @@ once_cell = "1.17.1"
 synstructure = "0.13.0"
 syn = "2.0.15"
 
-[dev-dependencies]
-expect-test = "1.4.1"
-
 [build-dependencies]
 lalrpop = "0.19.9"

--- a/macro/src/signature.rs
+++ b/macro/src/signature.rs
@@ -305,14 +305,18 @@ impl Signature {
                 Ok(quote_spanned!(self.span => java::Array<#e>))
             }
             RefType::TypeParameter(t) => {
-                assert!(
-                    self.in_scope_generics.contains(t),
-                    "generic type parameter `{:?}` not among in-scope parameters: {:?}",
-                    t,
-                    self.in_scope_generics,
-                );
-                let t = t.to_ident(self.span);
-                Ok(quote_spanned!(self.span => #t))
+                if self.in_scope_generics.contains(t) {
+                    let t = t.to_ident(self.span);
+                    Ok(quote_spanned!(self.span => #t))
+                } else {
+                    Err(SpanError {
+                        span: self.span,
+                        message: format!(
+                            "generic type parameter `{:?}` not among in-scope parameters: {:?}",
+                            t, self.in_scope_generics,
+                        ),
+                    })
+                }
             }
             RefType::Extends(ty) => {
                 let g = self.fresh_generic()?;

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,17 @@
+use ui_test::*;
+
+fn main() -> color_eyre::eyre::Result<()> {
+    let bless = std::env::args().any(|arg| arg == "--bless");
+    let mut config = Config::default();
+    config.root_dir = "tests/ui".into();
+    config.program.args.push("--crate-type".into());
+    config.program.args.push("lib".into());
+
+    if bless {
+        config.output_conflict_handling = OutputConflictHandling::Bless;
+    }
+
+    config.dependencies_crate_manifest_path = Some("Cargo.toml".into());
+
+    run_tests(config)
+}

--- a/tests/ui/type_mismatch.rs
+++ b/tests/ui/type_mismatch.rs
@@ -1,0 +1,9 @@
+duchess::java_package! { //~ ERROR: proc macro panicked
+    //~^ HELP: generic type parameter `Id { data: "bool" }` not among in-scope parameters: []
+    package java.lang;
+
+    public class java.lang.Object {
+        public java.lang.Object();
+        public native bool hashCode();
+    }
+}

--- a/tests/ui/type_mismatch.rs
+++ b/tests/ui/type_mismatch.rs
@@ -1,8 +1,7 @@
-duchess::java_package! { //~ ERROR: proc macro panicked
-    //~^ HELP: generic type parameter `Id { data: "bool" }` not among in-scope parameters: []
+duchess::java_package! {
     package java.lang;
 
-    public class java.lang.Object {
+    public class java.lang.Object { //~ ERROR: generic type parameter `Id { data: "bool" }` not among in-scope parameters: []
         public java.lang.Object();
         public native bool hashCode();
     }

--- a/tests/ui/type_mismatch.stderr
+++ b/tests/ui/type_mismatch.stderr
@@ -1,16 +1,8 @@
-error: proc macro panicked
- --> $DIR/type_mismatch.rs:1:1
+error: generic type parameter `Id { data: "bool" }` not among in-scope parameters: []
+ --> $DIR/type_mismatch.rs:4:5
   |
-1 | / duchess::java_package! {
-2 | |
-3 | |     package java.lang;
-4 | |
-... |
-8 | |     }
-9 | | }
-  | |_^
-  |
-  = help: message: generic type parameter `Id { data: "bool" }` not among in-scope parameters: []
+4 |     public class java.lang.Object {
+  |     ^^^^^^
 
 error: aborting due to previous error
 

--- a/tests/ui/type_mismatch.stderr
+++ b/tests/ui/type_mismatch.stderr
@@ -1,0 +1,16 @@
+error: proc macro panicked
+ --> $DIR/type_mismatch.rs:1:1
+  |
+1 | / duchess::java_package! {
+2 | |
+3 | |     package java.lang;
+4 | |
+... |
+8 | |     }
+9 | | }
+  | |_^
+  |
+  = help: message: generic type parameter `Id { data: "bool" }` not among in-scope parameters: []
+
+error: aborting due to previous error
+


### PR DESCRIPTION
fixes #5

I was unable to improve the error span further, as the duchess parser stringifies the class body before parsing with larlpop. We'd need to teach larlpop to handle token streams first.

Alternatively we can use the offset in the stringified version to walk the token stream to find the same offset and use that span.