### PR TITLE
Detect duplicate references in "extends" and "implements"

### DIFF
--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -468,7 +468,7 @@ impl std::fmt::Display for ScalarType {
 }
 
 /// A single identifier
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug)]
 pub struct Id {
     pub data: String,
 }
@@ -513,7 +513,7 @@ impl std::fmt::Display for Id {
 }
 
 /// A dotted identifier
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug)]
 pub struct DotId {
     /// Dotted components. Invariant: len >= 1.
     ids: Vec<Id>,

--- a/tests/ui/duplicate_extends.rs
+++ b/tests/ui/duplicate_extends.rs
@@ -1,0 +1,7 @@
+duchess::java_package! {
+    package log;
+
+    public class log.Builder extends java.lang.Object, java.lang.Object {} //~ ERROR: duplicate reference
+}
+
+fn main() {}

--- a/tests/ui/duplicate_extends.stderr
+++ b/tests/ui/duplicate_extends.stderr
@@ -1,0 +1,8 @@
+error: error in class `log.Builder`: duplicate reference in 'extends' to 'java.lang.Object'
+ --> $DIR/duplicate_extends.rs:4:5
+  |
+4 |     public class log.Builder extends java.lang.Object, java.lang.Object {}
+  |     ^^^^^^
+
+error: aborting due to previous error
+

--- a/tests/ui/duplicate_implements.rs
+++ b/tests/ui/duplicate_implements.rs
@@ -1,0 +1,7 @@
+duchess::java_package! {
+    package log;
+
+    public class log.Builder implements log.BuildStep, log.BuildStep {} //~ ERROR: duplicate reference
+}
+
+fn main() {}

--- a/tests/ui/duplicate_implements.stderr
+++ b/tests/ui/duplicate_implements.stderr
@@ -1,0 +1,8 @@
+error: error in class `log.Builder`: duplicate reference in 'implements' to 'log.BuildStep'
+ --> $DIR/duplicate_implements.rs:4:5
+  |
+4 |     public class log.Builder implements log.BuildStep, log.BuildStep {}
+  |     ^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Provide a simple error message if there are deplicate references for "extends" or "implements" in the class declaration.

Closes #43