### PR TITLE
Add transient flag support to grammar

### DIFF
--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -200,6 +200,7 @@ pub struct Flags {
     pub is_abstract: bool,
     pub is_static: bool,
     pub is_default: bool,
+    pub is_transient: bool,
 }
 
 impl Flags {
@@ -212,6 +213,7 @@ impl Flags {
             is_abstract: false,
             is_static: false,
             is_default: false,
+            is_transient: false,
         }
     }
 }

--- a/macro/src/class_info/javap_parser.lalrpop
+++ b/macro/src/class_info/javap_parser.lalrpop
@@ -145,6 +145,7 @@ Flags: Flags = {
     <f:Flags> "abstract" => Flags { is_abstract: true, ..f },
     <f:Flags> "static" => Flags { is_static: true, ..f },
     <f:Flags> "default" => Flags { is_default: true, ..f },
+    <f:Flags> "transient" => Flags { is_transient: true, ..f },
 };
 
 Privacy: Privacy = {


### PR DESCRIPTION
`java.lang.Class` has a `transient java.lang.ClassValue$ClassValueMap classValueMap` field that was breaking our `javap` parser.