### PR TITLE
Scalar derive

### DIFF
--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,4 +1,4 @@
-use duchess::{java, prelude::*, Global, Local};
+use duchess::{java, prelude::*, Global};
 use std::collections::HashMap;
 use thiserror::Error;
 

--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use inflector::Inflector;
 use proc_macro2::{Delimiter, Ident, Span, TokenStream, TokenTree};
 use quote::quote_spanned;
 
@@ -505,6 +506,12 @@ impl Id {
     pub fn to_ident(&self, span: Span) -> Ident {
         let data = self.data.replace("$", "__");
         Ident::new(&data, span)
+    }
+
+    pub fn to_snake_case(&self) -> Self {
+        Self {
+            data: self.data.to_snake_case(),
+        }
     }
 }
 

--- a/src/java.rs
+++ b/src/java.rs
@@ -257,6 +257,63 @@ mod auto {
             // public int compareTo(java.lang.Object);
             //   static {};
         }
+
+        package java.time;
+
+        public final class java.time.Instant {
+            public static final java.time.Instant EPOCH;
+            public static final java.time.Instant MIN;
+            public static final java.time.Instant MAX;
+            public static java.time.Instant now();
+            // public static java.time.Instant now(java.time.Clock);
+            // public static java.time.Instant ofEpochSecond(long);
+            public static java.time.Instant ofEpochSecond(long, long);
+            public static java.time.Instant ofEpochMilli(long);
+            // public static java.time.Instant from(java.time.temporal.TemporalAccessor);
+            // public static java.time.Instant parse(java.lang.CharSequence);
+            // public boolean isSupported(java.time.temporal.TemporalField);
+            // public boolean isSupported(java.time.temporal.TemporalUnit);
+            // public java.time.temporal.ValueRange range(java.time.temporal.TemporalField);
+            // public int get(java.time.temporal.TemporalField);
+            // public long getLong(java.time.temporal.TemporalField);
+            public long getEpochSecond();
+            public int getNano();
+            // public java.time.Instant with(java.time.temporal.TemporalAdjuster);
+            // public java.time.Instant with(java.time.temporal.TemporalField, long);
+            // public java.time.Instant truncatedTo(java.time.temporal.TemporalUnit);
+            // public java.time.Instant plus(java.time.temporal.TemporalAmount);
+            // public java.time.Instant plus(long, java.time.temporal.TemporalUnit);
+            public java.time.Instant plusSeconds(long);
+            public java.time.Instant plusMillis(long);
+            public java.time.Instant plusNanos(long);
+            // public java.time.Instant minus(java.time.temporal.TemporalAmount);
+            // public java.time.Instant minus(long, java.time.temporal.TemporalUnit);
+            public java.time.Instant minusSeconds(long);
+            public java.time.Instant minusMillis(long);
+            public java.time.Instant minusNanos(long);
+            // public <R> R query(java.time.temporal.TemporalQuery<R>);
+            // public java.time.temporal.Temporal adjustInto(java.time.temporal.Temporal);
+            // public long until(java.time.temporal.Temporal, java.time.temporal.TemporalUnit);
+            // public java.time.OffsetDateTime atOffset(java.time.ZoneOffset);
+            // public java.time.ZonedDateTime atZone(java.time.ZoneId);
+            public long toEpochMilli();
+            public int compareTo(java.time.Instant);
+            public boolean isAfter(java.time.Instant);
+            public boolean isBefore(java.time.Instant);
+            public boolean equals(java.lang.Object);
+            public int hashCode();
+            public java.lang.String toString();
+            // void writeExternal(java.io.DataOutput) throws java.io.IOException;
+            // static java.time.Instant readExternal(java.io.DataInput) throws java.io.IOException;
+            // public java.time.temporal.Temporal minus(long, java.time.temporal.TemporalUnit);
+            // public java.time.temporal.Temporal minus(java.time.temporal.TemporalAmount);
+            // public java.time.temporal.Temporal plus(long, java.time.temporal.TemporalUnit);
+            // public java.time.temporal.Temporal plus(java.time.temporal.TemporalAmount);
+            // public java.time.temporal.Temporal with(java.time.temporal.TemporalField, long);
+            // public java.time.temporal.Temporal with(java.time.temporal.TemporalAdjuster);
+            // public int compareTo(java.lang.Object);
+        }
+
     }
 }
 

--- a/tests/ui/derive_scalar_fields.rs
+++ b/tests/ui/derive_scalar_fields.rs
@@ -1,0 +1,16 @@
+//@run
+use duchess::{java, prelude::*};
+
+#[derive(duchess::ToJava)]
+#[java(java.time.Instant::ofEpochMilli)]
+struct RustInstant {
+    epoch_millis: i64,
+}
+
+pub fn main() -> duchess::GlobalResult<()> {
+    let rust = RustInstant { epoch_millis: 42 };
+    let java = rust.to_java().assert_not_null().global().execute()?;
+    let and_back = java.to_epoch_milli().execute()?;
+    assert_eq!(rust.epoch_millis, and_back);
+    Ok(())
+}


### PR DESCRIPTION
Adds support for scalar fields, which aren't a part of the `Upcast`
object heirarchy, by just copying them from the struct as is.

Along the way
 1. Make sure we rustify the method name
 2. Prefix duchess types with `duchess` in generated code
 3. Add `java.lang.Instant` bindings, which are convenient and give an
    example of using a scalar field (epoch millis) when deriving.