### PR TITLE
Use `$JAVA_HOME/bin/javap` if `$JAVA_HOME` is set

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -1,10 +1,8 @@
 # Setup instructions
 
-## JDK
+## JDK and JAVA_HOME
 
-**You need the `javap` tool on your path.** We recommend JDK17 or higher.
-
-Any JDK distribution will work. Here are some recommended options:
+You'll need to have a modern JDK installed. We recommend JDK17 or higher. Any JDK distribution will work. Here are some recommended options:
 
 * Ubuntu: Install one of the following packages...
     * `java-20-amazon-corretto-jdk/stable`
@@ -14,8 +12,16 @@ Any JDK distribution will work. Here are some recommended options:
     * Download [Amazon Coretto](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc)
     * Download a [pre-built openjdk package](https://openjdk.org/install/) suitable for your operating system
 
+**You'll need the `javap` tool from the JDK to build with Duchess.**  If the `JAVA_HOME` environment variable is set, Duchess will use it to locate `javap`. Otherwise, it will search for it on your `PATH`. Duchess relies on `javap` to reflect Java type information at build time. It will *not* be invoked at runtime.
+
 ## Configuring the CLASSPATH
 
 You will likely want to configure the CLASSPATH for your Rust project as well. You can do that via Cargo by creating a `.cargo/config.toml` file (see [this example from duchess itself](https://github.com/duchess-rs/duchess/blob/main/.cargo/config.toml)).
 
 If your Rust project uses external JAR files, you may want to configure it to download them as part of the build. The [viper test crate](https://github.com/duchess-rs/duchess/tree/main/test-crates/viper) gives an example of how to do that. It uses a [build.rs](https://github.com/duchess-rs/duchess/blob/main/test-crates/viper/build.rs) file.
+
+## Libjvm and linking
+
+By default, the `dylibjvm` feature is enabled and Duchess will dynamically load and link libjvm at runtime. Like with `javap`, it will first search for libjvm in `JAVA_HOME` if set. Otherwise it will look for `java` on your `PATH` to locate the JRE installation. Non-standard installations can also be configured using `JvmBuilder`.
+
+Without `dylibjvm`, libjvm must be statically linked.

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -12,11 +12,13 @@ You'll need to have a modern JDK installed. We recommend JDK17 or higher. Any JD
     * Download [Amazon Coretto](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc)
     * Download a [pre-built openjdk package](https://openjdk.org/install/) suitable for your operating system
 
-**You'll need the `javap` tool from the JDK to build with Duchess.**  If the `JAVA_HOME` environment variable is set, Duchess will use it to locate `javap`. Otherwise, it will search for it on your `PATH`. Duchess relies on `javap` to reflect Java type information at build time. It will *not* be invoked at runtime.
+**You'll need the `javap` tool from the JDK to build with Duchess.**  You'll want to configure the `JAVA_HOME` environment variable to point to your JDK installation. Duchess will use it to locate `javap`. Otherwise, Duchess will search for it on your `PATH`.  You can configure the environment variables used at build time via Cargo by creating a `.cargo/config.toml` file (see [this example from duchess itself](https://github.com/duchess-rs/duchess/blob/main/.cargo/config.toml)).
+
+Duchess relies on `javap` to reflect Java type information at build time. It will *not* be invoked at runtime.
 
 ## Configuring the CLASSPATH
 
-You will likely want to configure the CLASSPATH for your Rust project as well. You can do that via Cargo by creating a `.cargo/config.toml` file (see [this example from duchess itself](https://github.com/duchess-rs/duchess/blob/main/.cargo/config.toml)).
+You will likely want to configure the `CLASSPATH` for your Rust project as well. Like with `JAVA_HOME`, you can do that via Cargo by creating a `.cargo/config.toml` file.
 
 If your Rust project uses external JAR files, you may want to configure it to download them as part of the build. The [viper test crate](https://github.com/duchess-rs/duchess/tree/main/test-crates/viper) gives an example of how to do that. It uses a [build.rs](https://github.com/duchess-rs/duchess/blob/main/test-crates/viper/build.rs) file.
 

--- a/macro/src/reflect.rs
+++ b/macro/src/reflect.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, env, process::Command, sync::Arc};
+use std::{cell::RefCell, collections::BTreeMap, env, process::Command, sync::Arc, path::PathBuf};
 
 use proc_macro2::Span;
 
@@ -136,13 +136,18 @@ impl Reflector {
             return Ok(class);
         }
 
-        let mut command = Command::new("javap");
+        let mut javap_path = PathBuf::new();
+        if let Ok(java_home) = env::var("JAVA_HOME") {
+            javap_path.extend([java_home.as_str(), "bin"]);
+        }
+        javap_path.push("javap");
 
         let classpath = match env::var("CLASSPATH") {
             Ok(val) => val,
             Err(e) => panic!("duchess cannot read the CLASSPATH environment variable: {e}"),
         };
 
+        let mut command = Command::new(javap_path);
         command
             .arg("-cp")
             .arg(classpath)

--- a/macro/src/reflect.rs
+++ b/macro/src/reflect.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, env, process::Command, sync::Arc, path::PathBuf};
+use std::{cell::RefCell, collections::BTreeMap, env, path::PathBuf, process::Command, sync::Arc};
 
 use proc_macro2::Span;
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,8 +1,8 @@
 use std::ffi::CString;
 
 use crate::{
-    error::check_exception, java::lang::String as JavaString, jvm::JavaObjectExt,
-    plumbing::HasEnvPtr, raw::ObjectPtr, into_rust::IntoRust, Error, Jvm, JvmOp, Local,
+    error::check_exception, into_rust::IntoRust, java::lang::String as JavaString,
+    jvm::JavaObjectExt, plumbing::HasEnvPtr, raw::ObjectPtr, Error, Jvm, JvmOp, Local,
 };
 
 impl JvmOp for &str {


### PR DESCRIPTION
Some systems have multiple Java versions present and it's easy for the `javap` from one JDK to end up earlier on the path than the `javap` we're building against. The `JAVA_HOME` env var is a canonical way to identify and pass the JDK/JRE location to programs. We already use it for locating `libjvm` at runtime! If no `JAVA_HOME` was set, we fall back to relying on `PATH`, like we do for `libjvm`.

Updated the setup docs as well.