### PR TITLE
Fix type mismatch for ARM's c_char

### DIFF
--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -16,7 +16,7 @@ use crate::{
 use std::{
     any::Any,
     collections::HashMap,
-    ffi::{c_void, CStr},
+    ffi::{c_char, c_void, CStr},
     fmt::Display,
     panic::AssertUnwindSafe,
     ptr::NonNull,
@@ -283,8 +283,8 @@ impl<'jvm> Jvm<'jvm> {
                 .entry(class)
                 .or_insert(vec![])
                 .push(jni_sys::JNINativeMethod {
-                    name: java_function.name.as_ptr() as *mut i8,
-                    signature: java_function.signature.as_ptr() as *mut i8,
+                    name: java_function.name.as_ptr() as *mut c_char,
+                    signature: java_function.signature.as_ptr() as *mut c_char,
                     fnPtr: java_function.pointer.as_ptr() as *mut c_void,
                 });
         }

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::{c_char, CString};
 
 use crate::{
     error::check_exception, into_rust::IntoRust, java::lang::String as JavaString,
@@ -76,7 +76,7 @@ impl IntoRust<String> for &JavaString {
                         str_raw.as_ptr(),
                         0,
                         utf16_len,
-                        cesu_bytes.as_mut_ptr().cast::<i8>(),
+                        cesu_bytes.as_mut_ptr().cast::<c_char>(),
                     )
                 },
             );


### PR DESCRIPTION
ARM implementation of `c_char` is `u8` which causes a build failure for type mismatch when running `cargo build`

Update Duchess' JNINativeMethod type conversion to the general `c_char`

```
error[E0308]: mismatched types
   --> src/jvm.rs:286:27
    |
286 |                     name: java_function.name.as_ptr() as *mut i8,
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*mut u8`, found `*mut i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`
```

## Testing
- `cargo build`