### PR TITLE
Run tests on macOS and Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,8 +11,11 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
         distribution: 'corretto'
         java-version: '17'
     - name: Install mdBook
+      if: matrix.os == 'ubuntu-latest'
       run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz
     - name: Build
       run: cargo build --verbose
@@ -32,4 +33,5 @@ jobs:
     - name: Test client crates
       run: cargo test --all-targets --verbose --manifest-path=test-crates/Cargo.toml
     - name: Test book
+      if: matrix.os == 'ubuntu-latest'
       run: ./mdbook test book

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # windows-latest does not work because of https://github.com/oli-obk/ui_test/issues/147
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/test-crates/duchess-java-tests/Cargo.toml
+++ b/test-crates/duchess-java-tests/Cargo.toml
@@ -8,7 +8,7 @@ duchess = { path = "../.." }
 thiserror = "1.0.40"
 
 [dev-dependencies]
-ui_test = "0.10.0"
+ui_test = "0.17.0"
 
 [build_dependencies]
 walkdir = "2.3"

--- a/test-crates/duchess-java-tests/tests/ui.rs
+++ b/test-crates/duchess-java-tests/tests/ui.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use ui_test::*;
 
 fn main() -> color_eyre::eyre::Result<()> {
@@ -7,15 +8,15 @@ fn main() -> color_eyre::eyre::Result<()> {
     let bless = std::env::args().any(|arg| arg == "--bless");
 
     let mut config = Config::default();
-    config.root_dir = "tests/ui".into();
+    config.root_dir = Path::new("tests").join("ui");
 
     if bless {
         config.output_conflict_handling = OutputConflictHandling::Bless;
     }
 
-    // Place the build artifacts in the `target/ui` directory instead of in the
+    // Place the build artifacts in the `../target/ui` directory instead of in the
     // crate root.
-    config.out_dir = Some("../target/ui".into());
+    config.out_dir = Some(Path::new("..").join("target").join("ui"));
 
     // Make sure we can depend on duchess itself in our tests
     config.dependencies_crate_manifest_path = Some("Cargo.toml".into());

--- a/test-crates/duchess-java-tests/tests/ui.rs
+++ b/test-crates/duchess-java-tests/tests/ui.rs
@@ -7,8 +7,10 @@ fn main() -> color_eyre::eyre::Result<()> {
     // Tests can be blessed with `cargo test -- -- --bless`.
     let bless = std::env::args().any(|arg| arg == "--bless");
 
-    let mut config = Config::default();
-    config.root_dir = Path::new("tests").join("ui");
+    let mut config = Config {
+        ..Config::rustc(Path::new("tests").join("ui"))
+    };
+    let args = Args::test()?;
 
     if bless {
         config.output_conflict_handling = OutputConflictHandling::Bless;
@@ -16,16 +18,23 @@ fn main() -> color_eyre::eyre::Result<()> {
 
     // Place the build artifacts in the `../target/ui` directory instead of in the
     // crate root.
-    config.out_dir = Some(Path::new("..").join("target").join("ui"));
+    config.out_dir = Path::new("..").join("target").join("ui");
 
     // Make sure we can depend on duchess itself in our tests
-    config.dependencies_crate_manifest_path = Some("Cargo.toml".into());
+    config.dependencies_crate_manifest_path = Some(Path::new("Cargo.toml").into());
 
     let test_name = std::env::var_os("TESTNAME");
 
+    let text = if args.quiet {
+        ui_test::status_emitter::Text::quiet()
+    } else {
+        ui_test::status_emitter::Text::verbose()
+    };
+
     run_tests_generic(
-        config,
-        move |path| {
+        vec![config],
+        args,
+        move |path, _, _| {
             test_name
                 .as_ref()
                 .and_then(|name| {
@@ -38,7 +47,12 @@ fn main() -> color_eyre::eyre::Result<()> {
                 .unwrap_or(true)
                 && path.extension().map(|ext| ext == "rs").unwrap_or(false)
         },
-        |_, _| None,
-        status_emitter::TextAndGha,
+        default_per_file_config,
+        (
+            text,
+            ui_test::status_emitter::Gha::<true> {
+                name: "ui tests".into(),
+            },
+        )
     )
 }


### PR DESCRIPTION
This PR tests duchess on Windows and macOS as part of the CI.

For simplicity, `mdBook test` is still only executed on Ubuntu. To have something cross-platform for mdbook it might be better to use some published GitHub action.

Note that I upgraded the `ui_test` dependency from version `0.10` to `0.15`. Since `ui_test` `0.15` uses recently stabilized Rust features, users might have to do a `rustup update` before compiling duchess.