### PR TITLE
Fix str and local free bugs

### DIFF
--- a/book/src/internals.md
+++ b/book/src/internals.md
@@ -47,11 +47,12 @@ The underlying `sys::jobject` can be null, but we maintain the invariant that th
 ## Exceptions
 
 The [JNI exposes Java exception state](https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/functions.html#wp5234) via
- * `ExceptionCheck()` returning `true` if an unhandled exception has been thrown
- * `ExceptionOccurred()` returning a local reference to the thrown object
- * `ExceptionClear()` clearing the exception (if any)
 
-If an exception has occurred and isn't cleared before the next JNI call, the invoked Java code will immediately "see" the exception. Since this can cause an exception to propagate outside of the normal stack bubble-up, we must always call `duchess::EnvPtr::check_exception()?` after any JNI call that could throw. It will return `Err(duchess::Error::Thrown)` if one has occurred. The `duchess::EnvPtr::invoke_checked()` will both ensure the exception check occurred and that it was done in a way that any created local ref will be dropped correctly.
+* `ExceptionCheck()` returning `true` if an unhandled exception has been thrown
+* `ExceptionOccurred()` returning a local reference to the thrown object
+* `ExceptionClear()` clearing the exception (if any)
+
+If an exception has occurred and isn't cleared before the next JNI call, the invoked Java code will immediately "see" the exception. Since this can cause an exception to propagate outside of the normal stack bubble-up, we must always call `duchess::EnvPtr::check_exception()?` after any JNI call that could throw. It will return `Err(duchess::Error::Thrown)` if one has occurred. The `duchess::EnvPtr::invoke()` will both ensure the exception check occurred and that it was done in a way that any created local ref will be dropped correctly.
 
 ## Frequently asked questions
 

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -521,7 +521,7 @@ impl ClassInfo {
 
                         let env = jvm.env();
                         let obj: ::core::option::Option<duchess::Local<#ty>> = unsafe {
-                            env.invoke_checked(|env| env.NewObjectA, |env, f| f(
+                            env.invoke(|env| env.NewObjectA, |env, f| f(
                                 env,
                                 duchess::plumbing::JavaObjectExt::as_raw(&*class).as_ptr(),
                                 constructor.as_ptr(),
@@ -826,7 +826,7 @@ impl ClassInfo {
                     })?;
 
                     unsafe {
-                        jvm.env().invoke_checked(|env| env.#jni_call_fn, |env, f| f(
+                        jvm.env().invoke(|env| env.#jni_call_fn, |env, f| f(
                             env,
                             this.as_ptr(),
                             method.as_ptr(),
@@ -1013,7 +1013,7 @@ impl ClassInfo {
 
                     let class = <#this_ty as duchess::JavaObject>::class(jvm)?;
                     unsafe {
-                        jvm.env().invoke_checked(|env| env.#jni_call_fn, |env, f| f(
+                        jvm.env().invoke(|env| env.#jni_call_fn, |env, f| f(
                             env,
                             duchess::plumbing::JavaObjectExt::as_raw(&*class).as_ptr(),
                             method.as_ptr(),
@@ -1140,7 +1140,7 @@ impl ClassInfo {
 
                     let class = <#this_ty as duchess::JavaObject>::class(jvm)?;
                     unsafe {
-                        jvm.env().invoke_checked(|env| env.#jni_field_fn, |env, f| f(
+                        jvm.env().invoke(|env| env.#jni_field_fn, |env, f| f(
                             env,
                             duchess::plumbing::JavaObjectExt::as_raw(&*class).as_ptr(),
                             field.as_ptr(),

--- a/macro/src/parse.rs
+++ b/macro/src/parse.rs
@@ -43,14 +43,6 @@ impl Parser {
         }
     }
 
-    /// Returns an error struct located at the last consumed token.
-    pub fn error(&self, message: impl ToString) -> syn::Result<()> {
-        Err(syn::Error::new(
-            self.last_span().unwrap_or(Span::call_site()),
-            message.to_string(),
-        ))
-    }
-
     /// Returns the next token without consuming it, or None if no tokens remain.
     pub fn peek_token(&mut self) -> Option<&TokenTree> {
         self.tokens.peek()

--- a/macro/src/signature.rs
+++ b/macro/src/signature.rs
@@ -1,5 +1,3 @@
-use std::f32::consts::E;
-
 use crate::class_info::{ClassRef, Generic, Id, NonRepeatingType, RefType, ScalarType, Type};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote_spanned;

--- a/src/array.rs
+++ b/src/array.rs
@@ -141,7 +141,7 @@ macro_rules! primivite_array {
                     let env = jvm.env();
                     let array: Option<Local<JavaArray<$rust>>> = unsafe {
                         // SAFETY: env points to an attached JNI
-                        env.invoke_checked(|env| env.$new_fn, |env, f| f(env, len))
+                        env.invoke(|env| env.$new_fn, |env, f| f(env, len))
                     }?;
 
                     let Some(array) = array else {

--- a/src/array.rs
+++ b/src/array.rs
@@ -2,11 +2,9 @@ use std::marker::PhantomData;
 
 use crate::{
     cast::Upcast,
-    error::check_exception,
     java::{self, lang::Class},
     jvm::JavaView,
     plumbing::{FromRef, JavaObjectExt},
-    raw::{HasEnvPtr, ObjectPtr},
     to_java::ToJavaImpl,
     AsJRef, Error, IntoRust, JDeref, JavaObject, JavaType, Jvm, JvmOp, Local, Nullable,
     ScalarMethod, TryJDeref,
@@ -123,7 +121,7 @@ where
 
         let len = unsafe {
             jvm.env()
-                .invoke(|env| env.GetArrayLength, |env, f| f(env, this.as_ptr()))
+                .invoke_unchecked(|env| env.GetArrayLength, |env, f| f(env, this.as_ptr()))
         };
         Ok(len)
     }
@@ -141,27 +139,32 @@ macro_rules! primivite_array {
                     };
 
                     let env = jvm.env();
-                    let array = unsafe { env.invoke(|env| env.$new_fn, |env, f| f(env, len)) };
-                    if let Some(array) = ObjectPtr::new(array) {
-                        unsafe {
-                            env.invoke(|env| env.$set_fn, |env, f| f(
-                                env,
-                                array.as_ptr(),
-                                0,
-                                len,
-                                self.as_ptr().cast::<jni_sys::$java_ty>(),
-                            ));
-                        }
+                    let array: Option<Local<JavaArray<$rust>>> = unsafe {
+                        // SAFETY: env points to an attached JNI
+                        env.invoke_checked(|env| env.$new_fn, |env, f| f(env, len))
+                    }?;
 
-                        unsafe { Ok(Local::from_raw(env, array)) }
-                    } else {
-                        check_exception(jvm)?; // Likely threw OutOfMemoryError
+                    let Some(array) = array else {
+                        // NewArray should never return null unless an exception occurred (which we've already checked)
                         return Err(Error::JvmInternal(format!(
                             "failed to allocate `{}[{}]`",
                             $java_name,
                             len
                         )));
+                    };
+
+                    unsafe {
+                        // SAFETY: we allocated an array with the same len and type as self
+                        env.invoke_unchecked(|env| env.$set_fn, |env, f| f(
+                            env,
+                            array.as_raw().as_ptr(),
+                            0,
+                            len,
+                            self.as_ptr().cast::<jni_sys::$java_ty>(),
+                        ));
                     }
+
+                    Ok(array)
                 }
             }
 
@@ -189,7 +192,8 @@ macro_rules! primivite_array {
                     let mut vec = Vec::<$rust>::with_capacity(len as usize);
 
                     unsafe {
-                        jvm.env().invoke(|env| env.$get_fn, |env, f| f(
+                        // SAFETY: $rust is a Copy type and vec has at least as much capacity as the JVM array
+                        jvm.env().invoke_unchecked(|env| env.$get_fn, |env, f| f(
                             env,
                             self.as_raw().as_ptr(),
                             0,
@@ -198,7 +202,6 @@ macro_rules! primivite_array {
                         ));
                         vec.set_len(len as usize);
                     }
-                    check_exception(jvm)?;
 
                     Ok(vec)
                 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,9 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::Jvm;
-use crate::{
-    jvm::JavaObjectExt, raw::HasEnvPtr, refs::AsJRef, JavaObject, JvmOp, Local, TryJDeref,
-};
+use crate::{jvm::JavaObjectExt, refs::AsJRef, JavaObject, JvmOp, Local, TryJDeref};
 
 /// A trait to represent safe upcast operations for a [`JavaObject`].
 ///
@@ -52,7 +50,7 @@ where
 
         let env = jvm.env();
         let is_inst = unsafe {
-            env.invoke(
+            env.invoke_unchecked(
                 |env| env.IsInstanceOf,
                 |env, f| f(env, instance_raw.as_ptr(), class_raw.as_ptr()),
             ) == jni_sys::JNI_TRUE
@@ -105,7 +103,7 @@ where
 
             let instance_raw = instance.as_jref()?.as_raw();
             assert!(unsafe {
-                jvm.env().invoke(
+                jvm.env().invoke_unchecked(
                     |env| env.IsInstanceOf,
                     |env, f| f(env, instance_raw.as_ptr(), class_raw.as_ptr()),
                 ) == jni_sys::JNI_TRUE

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::{
 use thiserror::Error;
 
 use crate::AsJRef;
-use crate::{java::lang::Throwable, raw::HasEnvPtr, Global, Jvm, JvmOp, Local};
+use crate::{java::lang::Throwable, Global, Jvm, JvmOp, Local};
 
 /// Result returned by most Java operations that may contain a local reference
 /// to a thrown exception.
@@ -78,11 +78,4 @@ impl<'jvm> Error<Local<'jvm, Throwable>> {
             Error::JvmInternal(m) => Error::JvmInternal(m),
         }
     }
-}
-
-/// Used by codegen to check if the JVM exception flag is set, materializing an [`Error::Thrown`] if it is.
-#[doc(hidden)]
-pub fn check_exception<'jvm>(jvm: &mut Jvm<'jvm>) -> Result<'jvm, ()> {
-    let env = jvm.env();
-    env.check_exception()
 }

--- a/src/find.rs
+++ b/src/find.rs
@@ -14,7 +14,7 @@ pub fn find_class<'jvm>(
     let class: Option<Local<java::lang::Class>> = unsafe {
         // SAFETY: jni_name is a valid pointer to a nul-terminated byte string
         jvm.env()
-            .invoke_checked(|env| env.FindClass, |env, f| f(env, jni_name.as_ptr()))
+            .invoke(|env| env.FindClass, |env, f| f(env, jni_name.as_ptr()))
     }?;
     class.ok_or_else(|| {
         // Class not existing should've triggered NoClassDefFoundError so something strange is now happening

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ pub mod prelude {
 #[doc(hidden)]
 pub mod plumbing {
     pub use crate::cast::Upcast;
-    pub use crate::error::check_exception;
     pub use crate::find::{find_class, find_constructor, find_field, find_method};
     pub use crate::from_ref::FromRef;
     pub use crate::global::GlobalOp;
@@ -63,9 +62,7 @@ pub mod plumbing {
     pub use crate::jvm::JavaView;
     pub use crate::link::JavaFn;
     pub use crate::link::JavaFunction;
-    pub use crate::raw::{
-        EnvPtr, FieldPtr, FromJniValue, HasEnvPtr, IntoJniValue, MethodPtr, ObjectPtr,
-    };
+    pub use crate::raw::{EnvPtr, FieldPtr, FromJniValue, IntoJniValue, MethodPtr, ObjectPtr};
     pub use crate::refs::NullJRef;
     pub use crate::to_java::ToJavaImpl;
     pub use jni_sys;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -239,7 +239,7 @@ impl<'jvm> EnvPtr<'jvm> {
     ///
     /// The caller must ensure that the [`jni_sys::JNIEnv`] raw pointer is only used for this invocation.
     #[doc(hidden)]
-    pub unsafe fn invoke_checked<F, T: FromJniValue<'jvm>>(
+    pub unsafe fn invoke<F, T: FromJniValue<'jvm>>(
         self,
         fn_field: impl FnOnce(&jni_sys::JNINativeInterface_) -> Option<F>,
         call: impl FnOnce(*mut jni_sys::JNIEnv, F) -> T::JniValue,
@@ -296,7 +296,7 @@ impl<'jvm> EnvPtr<'jvm> {
         class: ObjectPtr,
         native_methods: &[jni_sys::JNINativeMethod],
     ) -> crate::Result<'jvm, ()> {
-        let result: jni_sys::jint = self.invoke_checked(
+        let result: jni_sys::jint = self.invoke(
             |f| f.RegisterNatives,
             |env, register_natives| {
                 let nm_ptr = native_methods.as_ptr();

--- a/src/str.rs
+++ b/src/str.rs
@@ -18,9 +18,8 @@ impl JvmOp for &str {
 
         let env = jvm.env();
         // SAFETY: c_string is non-null pointer to cesu8-encoded encoded string ending in a trailing nul byte
-        let string: Option<Local<JavaString>> = unsafe {
-            env.invoke_checked(|env| env.NewStringUTF, |env, f| f(env, c_string.as_ptr()))
-        }?;
+        let string: Option<Local<JavaString>> =
+            unsafe { env.invoke(|env| env.NewStringUTF, |env, f| f(env, c_string.as_ptr())) }?;
         string.ok_or_else(|| Error::JvmInternal("JVM faild to create new String".into()))
     }
 }

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,0 +1,43 @@
+use duchess::{java, prelude::*, Global};
+
+#[test]
+fn to_java_and_back() {
+    for example in [
+        //basic cases
+        "",
+        "abc\tdef",
+        "hello from 🦀!",
+        // various lengths
+        "a".repeat(1).as_str(),
+        "a".repeat(2).as_str(),
+        "a".repeat(3).as_str(),
+        "a".repeat(4).as_str(),
+        "a".repeat(63).as_str(),
+        "a".repeat(64).as_str(),
+        "a".repeat(65).as_str(),
+        "a".repeat(127).as_str(),
+        "a".repeat(128).as_str(),
+        "a".repeat(129).as_str(),
+        "a".repeat(1024 * 1024 - 1).as_str(),
+        "a".repeat(1024 * 1024).as_str(),
+        "a".repeat(1024 * 1024 + 1).as_str(),
+        // unicode code points of various UTF-8 lengths, some requiring surrogate pairs in Java
+        "$", // 1
+        "£", // 2
+        "€", // 3
+        "𐍈", // 4
+        // combinations of various codepoint lengths
+        "$£€𐍈€£$𐍈",
+        // nul byte
+        "\u{0000}",
+    ] {
+        let java: Global<java::lang::String> = example
+            .to_java()
+            .assert_not_null()
+            .global()
+            .execute()
+            .unwrap();
+        let and_back = (&*java).to_rust().execute().unwrap();
+        assert_eq!(example, and_back);
+    }
+}


### PR DESCRIPTION
This commit fixes a few safety bugs in the string and local ref code. It also cleans up the `invoke` code to make it easier to always free local refs. The `HasEnvPtr` trait was no longer providing any value so removed it along the way.

Bugs:
 1. Returning an empty string from Java would result in writing to a null pointer, since `Vec::with_capacity(0)` does not allocate and the JNI string functions always write a trailing nul byte.
 2. Allocate one extra byte in general when decoding Java strings to account for the trailing nul.
 3. Always wrap the return result of JNI function calls that can return a Java object in a `Local` before doing anything else, like checking for an exception. This ensures `Local::drop` is called and the ref is correctly freed.
 4. Fix up a few places where exceptions needed to be checked and weren't and vice versa.
 5. Fix up `?Sized` bounds so that `"abc".to_java()` compiles