### PR TITLE
check that reflected kind matches classinfo kind resolves #67

### DIFF
--- a/macro/src/check.rs
+++ b/macro/src/check.rs
@@ -38,12 +38,15 @@ impl ClassInfo {
                 format!("error in class `{}`: {m}", self.name),
             ));
         };
-        
+
         // does reflection kind match self.kind
         if info.kind != self.kind {
-            push_error_message(format!("reflected kind does not match ClassInfo.kind for {}", self.name));
+            push_error_message(format!(
+                "reflected kind does not match ClassInfo.kind for {}",
+                self.name
+            ));
         }
-        
+
         // We always allow people to elide generics, in which case
         // they are mirroring the "erased" version of the class.
         //

--- a/macro/src/check.rs
+++ b/macro/src/check.rs
@@ -38,7 +38,12 @@ impl ClassInfo {
                 format!("error in class `{}`: {m}", self.name),
             ));
         };
-
+        
+        // does reflection kind match self.kind
+        if info.kind != self.kind {
+            push_error_message(format!("reflected kind does not match ClassInfo.kind for {}", self.name));
+        }
+        
         // We always allow people to elide generics, in which case
         // they are mirroring the "erased" version of the class.
         //

--- a/macro/src/reflect.rs
+++ b/macro/src/reflect.rs
@@ -78,13 +78,23 @@ impl JavaPackage {
                 }
                 ClassDecl::Specified(c) => {
                     let dot_id = self.make_absolute_dot_id(c.span, &c.name)?;
-                    (
-                        dot_id.clone(),
-                        Arc::new(ClassInfo {
-                            name: dot_id,
-                            ..c.clone()
-                        }),
-                    )
+
+                    let info = Arc::new(ClassInfo {
+                        name: dot_id.clone(),
+                        ..c.clone()
+                    });
+
+                    if c.should_mirror_in_rust(info.flags.privacy)
+                        == info.should_mirror_in_rust(c.flags.privacy)
+                        && !info.should_mirror_in_rust(c.flags.privacy)
+                    {
+                        reflector
+                            .classes
+                            .borrow_mut()
+                            .entry(dot_id.clone())
+                            .or_insert(info.clone());
+                    }
+                    (dot_id.clone(), info.clone())
                 }
             };
 


### PR DESCRIPTION
checks that reflected kind matches `ClassInfo.kind` and if not pushes an error message. 

would this be a good place to check that fields match the reflected class #87