### PR TITLE
remove `pub` from package in `java_package!` example

### DIFF
--- a/book/src/call_java_from_rust.md
+++ b/book/src/call_java_from_rust.md
@@ -28,7 +28,7 @@ Using duchess, we can declare a Rust version of this class with the `java_packag
 duchess::java_package! {
     // First, identify the package you are mirroring,
     // and the visibility level that you want.
-    pub package com.widgard;
+    package com.widgard;
 
     // Next, identify classes whose methods you would like to call. 
     // The `*` indicates "reflect all methods".


### PR DESCRIPTION
Thank you for building duchess, I've had a lot of fun testing it out today to replace a house of cards I have in a toy project! I found that having the `pub` present in the macro input would lead to a compile error along the  lines of "unexpected input".

I suspect that at some point this support for visibility was removed? Or maybe it's a placeholder for functionality yet planned for implementation?