### PR TITLE
Improvements to `DUCHESS_DEBUG` and other misc small changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+### Running Tests
+Tests are split into two parts:
+1. Unit tests, run by running `cargo test` in the root directory.
+2. Integration tests (containing usages of the proc macro and ui-tests): `(cd test-crates && cargo test)`
+
+You can run both of these with `just test` (see [just](https://github.com/casey/just)) for more information. Just is not required to contribute but may save you a small amount of time.
+
+The [UI tests](test-crates) are currently tested against [Rust 1.76.0](test-crates/rust-toolchain.toml).
+
+### Debugging
+Duchess looks for the `DUCHESS_DEBUG` environment variable during proc-macro expansion. When this variable is set, if it is `true` or `1`, **all** generated code will be formatted and dumped to a directory. Clickable links are printed to stderr:
+
+For example:
+```
+file:////var/folders/20/gm3mpm1n6lj3r3tb6q2hx2_80000gr/T/.tmpjJadBD/auth_Authenticated.rs
+file:////var/folders/20/gm3mpm1n6lj3r3tb6q2hx2_80000gr/T/.tmpjJadBD/auth_AuthorizeRequest.rs
+file:////var/folders/20/gm3mpm1n6lj3r3tb6q2hx2_80000gr/T/.tmpjJadBD/auth_HttpAuth.rs
+```
+
+If you want to filter specific Java class paths, you can pass a string like `auth` or `java.lang`:
+```
+DUCHESS_DEBUG=java.lang
+```
+
+This will only dump debug information for these specific classes.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Check out the...
 
 ## Curious to get involved?
 
-Look for [issues tagged with good first issue][] and join the [Zulip][].
+Look for [issues tagged with good first issue][] and join the [Zulip][]. For more information on how to develop duchess, 
+see [Contributing][].
 
 [issues tagged with good first issue]: https://github.com/duchess-rs/duchess/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [Zulip]: https://duchess.zulipchat.com/
+[Contributing]: CONTRIBUTING.md

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+alias t := test
+alias ut:= unit-test
+alias it := integration-test
+unit-test:
+  cargo test
+
+integration-test:
+    (cd test-crates && cargo test)
+
+test: unit-test integration-test

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -14,6 +14,8 @@ proc-macro = true
 anyhow = "1.0.70"
 lalrpop-util = { version = "0.19.9", features = ["lexer"] }
 litrs = "0.4.0"
+lazy_static = "1.4.0"
+tempfile = "3.8.1"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 regex = "1"

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -91,6 +91,16 @@ fn debug_tokens(name: impl std::fmt::Display, token_stream: &proc_macro2::TokenS
                 std::fs::write(&path, format!("{token_stream:?}")).expect("failed to write to debug file");
             }
         }
-        eprintln!("file:///{}", path.display())
+        // in JetBrains terminal, links are only clickable with a `file:///` prefix. But in VsCode
+        // iTerm, and most other terminals, they are only clickable if they are absolute paths.
+        if running_in_jetbrains() {
+            eprintln!("file:///{}", path.display())
+        } else {
+            eprintln!("{}", path.display())
+        }
     }
+}
+
+fn running_in_jetbrains() -> bool {
+    std::env::var("TERMINAL_EMULATOR").map(|var|var.contains("JetBrains")).unwrap_or_default()
 }

--- a/macro/src/reflect.rs
+++ b/macro/src/reflect.rs
@@ -163,7 +163,8 @@ impl Reflector {
             return Err(syn::Error::new(
                 span,
                 format!(
-                    "unsuccessful execution of `{command:?}`: {}",
+                    "unsuccessful execution of `{command:?}` (exit status: {}): {}",
+                    output.status,
                     String::from_utf8(output.stderr).unwrap_or(String::from("error"))
                 ),
             ));

--- a/src/null.rs
+++ b/src/null.rs
@@ -1,6 +1,4 @@
-use std::marker::PhantomData;
-
-use crate::{AsJRef, JavaObject, NullJRef, TryJDeref};
+use crate::{AsJRef, JavaObject, NullJRef};
 
 #[derive(Copy, Clone)]
 pub struct Null;

--- a/test-crates/rust-toolchain.toml
+++ b/test-crates/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.76.0"
+

--- a/test-crates/rust-toolchain.toml
+++ b/test-crates/rust-toolchain.toml
@@ -1,3 +1,4 @@
+# the UI tests depend on a specific version of Rust since the compiler error messages change slightly release-to-release
 [toolchain]
 channel = "1.76.0"
 


### PR DESCRIPTION
- Pin a rust toolchain for test-crates since the expectations depend on a specific Rust version
- Add a contribution guide
- Improve (and document) `DUCHESS_DEBUG`. DUCHESS_DEBUG will now dump the formatted Rust code to the file and print clickable links to the terminal.
<img width="809" alt="Screenshot 2024-03-20 at 12 12 55 PM" src="https://github.com/duchess-rs/duchess/assets/492903/528b755b-3cd4-4f8f-ae94-147e022ec549">