### PR TITLE
Coverage testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
+concurrency:
+  group: ci-yaml-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,6 +20,7 @@ jobs:
       matrix:
         # windows-latest does not work because of https://github.com/oli-obk/ui_test/issues/147
         os: [ubuntu-latest, macos-latest]
+        java-version: ['17', '21']
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -23,7 +29,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
-        java-version: '17'
+        java-version: ${{ matrix.java-version }}
     - name: Install mdBook
       if: matrix.os == 'ubuntu-latest'
       run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,3 +42,27 @@ jobs:
     - name: Test book
       if: matrix.os == 'ubuntu-latest'
       run: ./mdbook test book
+
+  coverage:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+      - uses: Swatinem/rust-cache@v2
+      - name: install just
+        run: |
+          cargo install just
+      - name: coverage-deps
+        run: just coverage-tools
+      - name:
+        run: just coverage
+        env:
+          NO_OPEN: true
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: ui-coverage-report
+          path: target/ui-coverage-report/

--- a/justfile
+++ b/justfile
@@ -8,3 +8,83 @@ integration-test:
     (cd test-crates && cargo test)
 
 test: unit-test integration-test
+
+coverage-tools:
+  rustup component add llvm-tools 
+  cargo install cargo-binutils
+  cargo install rustfilt
+
+test_coverage := "test-coverage"
+coverage_file := "duchess-coverage-%p-%10m.profraw"
+
+coverage-clean:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  target={{justfile_directory()}}/target
+  coverage_dir=$target/{{test_coverage}}
+  rm -rf $coverage_dir
+  rm -rf $target/ui-coverage-report
+
+
+coverage-unit-tests:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  target={{justfile_directory()}}/target
+  coverage_dir=$target/{{test_coverage}}
+  (RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE=$coverage_dir/{{coverage_file}} cargo test) || true
+
+
+coverage-ui-test:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  target={{justfile_directory()}}/target
+  coverage_dir=$target/{{test_coverage}}
+  (cd test-crates && RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE=$coverage_dir/duchess-%p-%10m.profraw cargo test) || true
+
+coverage-show:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  target={{justfile_directory()}}/target
+  coverage_dir=$target/{{test_coverage}}
+  # For some reason, the LLVM tools are also emitting profiling data, suppress this.
+  export LLVM_PROFILE_FILE=/dev/null
+  echo "Found profile data from $(ls $coverage_dir/duchess*.profraw | wc -l) profile runs"
+  rust-profdata merge -sparse $coverage_dir/duchess*.profraw -o $coverage_dir/test-crates.profdata
+  # Determine the operating system
+  OS="$(uname)"
+  if [[ "$OS" == "Darwin" ]]; then
+      FILE_EXTENSION="dylib"
+  elif [[ "$OS" == "Linux" ]]; then
+      FILE_EXTENSION="so"
+  else
+      echo "Unsupported OS"
+      exit 1
+  fi
+  rust-cov show --instr-profile $coverage_dir/test-crates.profdata -Xdemangler=rustfilt \
+    --format=html \
+    --output-dir $target/ui-coverage-report \
+    --object test-crates/target/ui/greeting \
+       $( \
+      for file in \
+        $( \
+          RUSTFLAGS="-C instrument-coverage" \
+          LLVM_PROFILE_FILE="$target/ignored-%p-%10m.profraw" \
+            cargo test --tests --no-run --message-format=json \
+              | jq -r "select(.profile.test == true) | .filenames[]" \
+              | grep -v dSYM - \
+        ); \
+      do \
+        printf "%s %s " -object $file; \
+      done \
+    ) \
+    --object $target/debug/deps/libduchess_macro-*.$FILE_EXTENSION \
+    --show-instantiations=false \
+    --sources {{justfile_directory()}}/src \
+    --sources {{justfile_directory()}}/macro
+  # Allow CI to suppress autoopening the report
+  if [ -z "${NO_OPEN+x}" ]; then
+    open $target/ui-coverage-report/index.html
+  fi
+
+
+coverage: coverage-clean coverage-unit-tests coverage-ui-test coverage-show

--- a/test-crates/duchess-java-tests/tests/ui.rs
+++ b/test-crates/duchess-java-tests/tests/ui.rs
@@ -10,6 +10,15 @@ fn main() -> color_eyre::eyre::Result<()> {
     let mut config = Config {
         ..Config::rustc(Path::new("tests").join("ui"))
     };
+
+    if std::env::var("RUSTFLAGS")
+        .unwrap_or_default()
+        .contains("instrument-coverage")
+    {
+        config.program.args.push("-C".into());
+        config.program.args.push("instrument-coverage".into());
+    }
+
     let args = Args::test()?;
 
     if bless {
@@ -53,6 +62,6 @@ fn main() -> color_eyre::eyre::Result<()> {
             ui_test::status_emitter::Gha::<true> {
                 name: "ui tests".into(),
             },
-        )
+        ),
     )
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,0 +1,28 @@
+use duchess::{java, Global, JvmOp, ToJava};
+
+macro_rules! test_array {
+    ($type: ty, $item: expr) => {
+        for test_array in [vec![$item], vec![], vec![$item, $item, $item]] {
+            let java: Global<java::Array<$type>> = test_array
+                .to_java()
+                .assert_not_null()
+                .global()
+                .execute()
+                .unwrap();
+            let and_back = (&*java).to_rust().execute().unwrap();
+            assert_eq!(test_array, and_back);
+        }
+    };
+}
+
+#[test]
+fn test_array_types() {
+    test_array!(bool, true);
+    test_array!(i8, 5_i8);
+    test_array!(u16, 5_u16);
+    test_array!(i16, 5_i16);
+    test_array!(i32, 5_i32);
+    test_array!(i64, 5_i64);
+    test_array!(f32, 5_f32);
+    test_array!(f64, 5_f64);
+}


### PR DESCRIPTION
1. Adds testing against JDK 21
2. Adds a `just coverage` target. This produces a coverage report that covers both the duchess library & the proc macro as well. It changes the ui-test framework to conditionally run rustc with `-C instrument-coverage`.
3. Adds some unit tests to validate that the coverage report is working.

In CI, a the coverage report is added as an archive.

## Why doesn't this use `cargo llvm-cov`?

Cargo llvm-cov seeks to accomplish a lot of the same things, but it can't properly (and I don't think it can be configured to) properly construct the right llvm-cov incantation to produce a unified coverage report. I wasn't able to get it to not just crash.