### PR TITLE
Automatically publish coverage information to GitHub pages

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -32,6 +32,10 @@ jobs:
       MDBOOK_VERSION: 0.4.21
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+      # Needed so that the coverage tests can actually work & rustdoc can successfully build examples
       - uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
@@ -47,12 +51,28 @@ jobs:
         uses: actions/configure-pages@v3
       - name: Build with mdBook
         run: ./mdbook build book
+      #- name: stub
+      #  run: mkdir -p target/ui-coverage-report && echo "hello world!" > target/ui-coverage-report/index.html
+      - name: install just
+        run: |
+          cargo install just
+      - name: coverage-deps
+        run: just coverage-tools
+      - name:
+        run: just coverage
+        env:
+          NO_OPEN: true
+      # Needed so that mdbook can point directly to rustdoc
       - name: Rust rustdoc
         run: cargo doc --target-dir book/book/rustdoc
+      - name: Assemble pages
+        run: |
+          mv book/book pages-site
+          mv target/ui-coverage-report pages-site/coverage
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./book/book
+          path: ./pages-site/
 
   # Deployment job
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Duchess: silky smooth Java integration
 
 [<img src="https://img.shields.io/badge/chat-on%20Zulip-green"></img>][Zulip]
+[<img src="https://img.shields.io/badge/Coverage-green"></img>][Coverage]
 
 Duchess is a Rust crate that makes it easy, ergonomic, and efficient to interoperate with Java code.
 
@@ -45,8 +46,9 @@ Check out the...
 ## Curious to get involved?
 
 Look for [issues tagged with good first issue][] and join the [Zulip][]. For more information on how to develop duchess, 
-see [Contributing][].
+see [Contributing][]. You may also be able to improve test [coverage].
 
 [issues tagged with good first issue]: https://github.com/duchess-rs/duchess/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [Zulip]: https://duchess.zulipchat.com/
 [Contributing]: CONTRIBUTING.md
+[Coverage]: https://duchess-rs.github.io/duchess/coverage

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -6,6 +6,8 @@ Duchess is a Rust crate that makes it [safe](./safety.md), ergonomic, and effici
 
 <img src="duchess.svg" width="300"></img>
 
+<a href="./coverage">Coverage Report</a>
+
 
 ## TL;DR
 

--- a/test-crates/rust-toolchain.toml
+++ b/test-crates/rust-toolchain.toml
@@ -1,4 +1,0 @@
-# the UI tests depend on a specific version of Rust since the compiler error messages change slightly release-to-release
-[toolchain]
-channel = "1.76.0"
-


### PR DESCRIPTION
This CR publishes coverage information to GitHub pages when PRs are merged to main. Coverage is in a subdirectory of the main site, so all existing links continue to work. You can play around with how this will work on my [fork](https://rcoh.github.io/duchess/)

I also updated the README to add some links to the coverage information.

Along the way, I fixed some broken links and typos in the threat model and deleted rust-toolchain since we now have the bless script.