### PR TITLE
Add additional test coverage

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,6 +64,7 @@ coverage-show:
     --format=html \
     --output-dir $target/ui-coverage-report \
     --object test-crates/target/ui/greeting \
+    --object test-crates/target/ui/exceptions \
        $( \
       for file in \
         $( \

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ coverage-show:
     --format=html \
     --output-dir $target/ui-coverage-report \
     --object test-crates/target/ui/tests/ui/examples/greeting \
-    --object test-crates/target/ui/tests/ui/examples/exceptions \
+    --object test-crates/target/ui/tests/ui/exceptions \
        $( \
       for file in \
         $( \

--- a/src/find.rs
+++ b/src/find.rs
@@ -73,6 +73,7 @@ pub fn find_field<'jvm>(
     class: impl AsRef<java::lang::Class>,
     jni_name: &CStr,
     jni_descriptor: &CStr,
+    // Note: there are no usages currently of `is_statc: false`. See https://github.com/duchess-rs/duchess/issues/85
     is_static: bool,
 ) -> Result<'jvm, FieldPtr> {
     let class = class.as_ref().as_raw();

--- a/test-crates/duchess-java-tests/java/exceptions/DifferentException.java
+++ b/test-crates/duchess-java-tests/java/exceptions/DifferentException.java
@@ -1,0 +1,5 @@
+package exceptions;
+
+public class DifferentException extends Exception {
+
+}

--- a/test-crates/duchess-java-tests/java/exceptions/ThrowExceptions.java
+++ b/test-crates/duchess-java-tests/java/exceptions/ThrowExceptions.java
@@ -1,6 +1,9 @@
 package exceptions;
 
 public class ThrowExceptions {
+    public static String staticStringNotNull = "notnull";
+    public static String nullString;
+
     public void throwRuntime() {
         throw new RuntimeException("something has gone horribly wrong");
     }

--- a/test-crates/duchess-java-tests/tests/ui/exceptions.rs
+++ b/test-crates/duchess-java-tests/tests/ui/exceptions.rs
@@ -1,17 +1,19 @@
 //@run
-use duchess::java;
 use duchess::prelude::*;
 use duchess::Global;
+use duchess::{java, Jvm};
 
 duchess::java_package! {
     package exceptions;
 
     public class ThrowExceptions { * }
+    public class DifferentException { * }
 }
 
 pub fn main() -> duchess::GlobalResult<()> {
     check_exceptions()?;
     check_static_fields()?;
+    catch_exceptions()?;
 
     Ok(())
 }
@@ -23,6 +25,47 @@ fn check_static_fields() -> duchess::GlobalResult<()> {
         .execute()?
         .unwrap();
     assert_eq!("notnull", result);
+    Ok(())
+}
+
+fn catch_exceptions() -> duchess::GlobalResult<()> {
+    // Note: perhaps an API issue, I was only able to get catch to work in a non-global context, hence `Jvm::with`
+    Jvm::with(|jvm| {
+        let thrower = exceptions::ThrowExceptions::new()
+            .execute_with(jvm)
+            .unwrap();
+
+        let caught_exception = thrower
+            .throw_runtime()
+            .catch::<java::lang::RuntimeException>()
+            .execute_with(jvm)
+            .unwrap();
+        assert!(
+            // it matches the expected exception type so, outer is Ok, inner is err
+            matches!(&caught_exception, Err(_)),
+            "{:?}",
+            caught_exception
+        );
+
+        let caught_exception = thrower
+            .null_object()
+            .catch::<java::lang::RuntimeException>()
+            .execute_with(jvm)
+            .unwrap()
+            .expect("returns ok!");
+
+        // This errors out because `try_extract_exception` calls `Jvm::with`.
+        let caught_exception = thrower
+            .throw_runtime()
+            .catch::<exceptions::DifferentException>()
+            .execute_with(jvm);
+        assert!(matches!(caught_exception, Err(duchess::Error::Thrown(_))));
+
+        // This is a reproduction of https://github.com/duchess-rs/duchess/issues/142
+        assert_eq!(format!("{:?}", caught_exception), "Err(Java invocation threw: failed to get message: attempted to nest `Jvm::with` calls)");
+        Ok(())
+    })
+    .unwrap();
     Ok(())
 }
 

--- a/test-crates/duchess-java-tests/tests/ui/exceptions.rs
+++ b/test-crates/duchess-java-tests/tests/ui/exceptions.rs
@@ -10,6 +10,23 @@ duchess::java_package! {
 }
 
 pub fn main() -> duchess::GlobalResult<()> {
+    check_exceptions()?;
+    check_static_fields()?;
+
+    Ok(())
+}
+
+fn check_static_fields() -> duchess::GlobalResult<()> {
+    let result = exceptions::ThrowExceptions::get_static_string_not_null()
+        .global()
+        .to_rust()
+        .execute()?
+        .unwrap();
+    assert_eq!("notnull", result);
+    Ok(())
+}
+
+fn check_exceptions() -> duchess::GlobalResult<()> {
     let thrower = exceptions::ThrowExceptions::new().global().execute()?;
 
     let result = thrower

--- a/tests/nested_jvm.rs
+++ b/tests/nested_jvm.rs
@@ -1,0 +1,11 @@
+use duchess::Jvm;
+
+#[test]
+fn nested_jvm_with() {
+    Jvm::with(|_jvm| {
+        let err = Jvm::with(|_jvm| Ok(())).expect_err("nested JVMs are illegal");
+        assert!(matches!(err, duchess::Error::NestedUsage));
+        Ok(())
+    })
+    .expect("returns Ok")
+}


### PR DESCRIPTION
Adds coverage for a few more areas that were missing coverage (previous: 63%, now 67%)

- reading static fields
- catching exceptions with `.catch()`
- correctly forbidding nested JVMs from being created

In the process I discovered #142 which I'm not sure how to best fix. There is a test included here that reproduces that behavior.
