### PR TITLE
Fix method descriptor for `X extends Y`

### DIFF
--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -280,7 +280,12 @@ impl Constructor {
         }
     }
 
-    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+    /// Returns the JVM descriptor script for the constructor.
+    ///
+    /// # Parameters
+    ///
+    /// * `ctx` is the generics scope of the class.
+    pub fn descriptor(&self, ctx: &GenericsScope<'_>) -> String {
         let ctx = &ctx.nest(&self.generics);
         format!(
             "({})V",
@@ -318,7 +323,12 @@ impl Method {
         }
     }
 
-    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+    /// Returns the JVM descriptor for the method.
+    ///
+    /// # Parameters
+    ///
+    /// * `ctx` is the generics scope of the class.
+    pub fn descriptor(&self, ctx: &GenericsScope<'_>) -> String {
         let ctx = &ctx.nest(&self.generics);
         format!(
             "({}){}",
@@ -426,7 +436,12 @@ impl Type {
         }
     }
 
-    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+    /// Returns the JVM descriptor for this type, suitable for embedding a method descriptor.
+    ///
+    /// # Parameters
+    ///
+    /// * `ctx` is the generics scope where the type appears.
+    pub fn descriptor(&self, ctx: &GenericsScope<'_>) -> String {
         self.to_non_repeating().descriptor(ctx)
     }
 }
@@ -471,7 +486,12 @@ pub enum NonRepeatingType {
 }
 
 impl NonRepeatingType {
-    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+    /// Returns the JVM descriptor for this type, suitable for embedding a method descriptor.
+    ///
+    /// # Parameters
+    ///
+    /// * `ctx` is the generics scope where the type appears.
+    pub fn descriptor(&self, ctx: &GenericsScope<'_>) -> String {
         match self {
             NonRepeatingType::Ref(r) => match r {
                 RefType::Class(c) => format!("L{};", c.name.to_jni_name()),

--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -280,12 +280,13 @@ impl Constructor {
         }
     }
 
-    pub fn descriptor(&self) -> String {
+    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+        let ctx = &ctx.nest(&self.generics);
         format!(
             "({})V",
             self.argument_tys
                 .iter()
-                .map(|a| a.descriptor())
+                .map(|a| a.descriptor(ctx))
                 .collect::<String>()
         )
     }
@@ -317,16 +318,17 @@ impl Method {
         }
     }
 
-    pub fn descriptor(&self) -> String {
+    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+        let ctx = &ctx.nest(&self.generics);
         format!(
             "({}){}",
             self.argument_tys
                 .iter()
-                .map(|a| a.descriptor())
+                .map(|a| a.descriptor(ctx))
                 .collect::<String>(),
             self.return_ty
                 .as_ref()
-                .map(|r| r.descriptor())
+                .map(|r| r.descriptor(ctx))
                 .unwrap_or_else(|| format!("V")),
         )
     }
@@ -424,8 +426,40 @@ impl Type {
         }
     }
 
-    pub fn descriptor(&self) -> String {
-        self.to_non_repeating().descriptor()
+    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
+        self.to_non_repeating().descriptor(ctx)
+    }
+}
+
+/// Track generics currently in scope
+///
+/// In order to resolve descriptors for methods containing `<X extends Y>`, we need to know how `T` was declared.
+pub enum GenericsScope<'a> {
+    Empty,
+    Generics(&'a [Generic], &'a GenericsScope<'a>),
+}
+
+impl<'a> GenericsScope<'a> {
+    /// Find a generic within this scope by name
+    fn find(&self, ty: &Id) -> Option<&Generic> {
+        match self {
+            GenericsScope::Empty => None,
+            GenericsScope::Generics(g, inner) => g.iter().find(|g| &g.id == ty).or(inner.find(ty)),
+        }
+    }
+
+    /// Add an additional layer to this scope (e.g. combining generics from a class with generics from a method)
+    ///
+    /// The newly provided generics are higher priority than the inner generics (but
+    /// I don't think we can have namespace collisions here in Java anyway)
+    fn nest(&'a self, generics: &'a [Generic]) -> GenericsScope<'a> {
+        GenericsScope::Generics(generics, self)
+    }
+}
+
+impl<'a> From<&'a ClassInfo> for GenericsScope<'a> {
+    fn from(value: &'a ClassInfo) -> Self {
+        Self::Generics(&value.generics, &GenericsScope::Empty)
     }
 }
 
@@ -437,18 +471,24 @@ pub enum NonRepeatingType {
 }
 
 impl NonRepeatingType {
-    pub fn descriptor(&self) -> String {
+    pub fn descriptor(&self, ctx: &GenericsScope) -> String {
         match self {
             NonRepeatingType::Ref(r) => match r {
                 RefType::Class(c) => format!("L{};", c.name.to_jni_name()),
-                RefType::Array(r) => format!("[{}", r.descriptor()),
+                RefType::Array(r) => format!("[{}", r.descriptor(ctx)),
 
                 // FIXME(#42): The descriptor actually depends on how the type
                 // parameter was declared!
-                RefType::TypeParameter(_)
-                | RefType::Extends(_)
-                | RefType::Super(_)
-                | RefType::Wildcard => format!("Ljava/lang/Object;"),
+                RefType::TypeParameter(id) => {
+                    let generic = ctx.find(id).expect("generic did not exist.");
+                    match generic.extends.get(0) {
+                        Some(c) => format!("L{};", c.name.to_jni_name()),
+                        _ => format!("Ljava/lang/Object;"),
+                    }
+                }
+                RefType::Extends(_) | RefType::Super(_) | RefType::Wildcard => {
+                    format!("Ljava/lang/Object;")
+                }
             },
             NonRepeatingType::Scalar(s) => match s {
                 ScalarType::Int => format!("I"),

--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -172,6 +172,10 @@ impl ClassInfo {
             | (Privacy::Default, ClassKind::Class) => false,
         }
     }
+
+    pub fn generics_scope(&self) -> GenericsScope {
+        GenericsScope::Generics(&self.generics, &GenericsScope::Empty)
+    }
 }
 
 #[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
@@ -472,12 +476,6 @@ impl<'a> GenericsScope<'a> {
     }
 }
 
-impl<'a> From<&'a ClassInfo> for GenericsScope<'a> {
-    fn from(value: &'a ClassInfo) -> Self {
-        Self::Generics(&value.generics, &GenericsScope::Empty)
-    }
-}
-
 /// A variant of type
 #[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
 pub enum NonRepeatingType {
@@ -497,8 +495,6 @@ impl NonRepeatingType {
                 RefType::Class(c) => format!("L{};", c.name.to_jni_name()),
                 RefType::Array(r) => format!("[{}", r.descriptor(ctx)),
 
-                // FIXME(#42): The descriptor actually depends on how the type
-                // parameter was declared!
                 RefType::TypeParameter(id) => {
                     let generic = ctx.find(id).expect("generic did not exist.");
                     match generic.extends.get(0) {

--- a/macro/src/class_info.rs
+++ b/macro/src/class_info.rs
@@ -173,7 +173,7 @@ impl ClassInfo {
         }
     }
 
-    pub fn generics_scope(&self) -> GenericsScope {
+    pub fn generics_scope(&self) -> GenericsScope<'_> {
         GenericsScope::Generics(&self.generics, &GenericsScope::Empty)
     }
 }

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -439,14 +439,14 @@ impl ClassInfo {
 
         let java_class_generics = self.class_generic_names();
 
-        let jni_descriptor = jni_c_str(constructor.descriptor(), self.span);
+        let jni_descriptor = jni_c_str(constructor.descriptor(&self.into()), self.span);
 
         // Code to convert each input appropriately
         let prepare_inputs = self.prepare_inputs(&input_names, &constructor.argument_tys);
 
         // for debugging JVM invocation failures
         let name = Literal::string(&self.name.to_string());
-        let descriptor = Literal::string(&constructor.descriptor());
+        let descriptor = Literal::string(&constructor.descriptor(&self.into()));
 
         let output = quote_spanned!(self.span =>
             pub fn new(
@@ -719,7 +719,7 @@ impl ClassInfo {
             None => None,
         };
 
-        let jni_descriptor = jni_c_str(&method.descriptor(), self.span);
+        let jni_descriptor = jni_c_str(&method.descriptor(&self.into()), self.span);
 
         // Code to convert each input appropriately
         let prepare_inputs = self.prepare_inputs(&input_names, &method.argument_tys);
@@ -920,7 +920,7 @@ impl ClassInfo {
             None => None,
         };
 
-        let jni_descriptor = jni_c_str(&method.descriptor(), self.span);
+        let jni_descriptor = jni_c_str(&method.descriptor(&self.into()), self.span);
 
         // Code to convert each input appropriately
         let prepare_inputs = self.prepare_inputs(&input_names, &method.argument_tys);
@@ -1085,7 +1085,7 @@ impl ClassInfo {
         let jni_field_fn = sig.jni_static_field_get_fn(&field.ty)?;
 
         let jni_field = jni_c_str(&*field.name, self.span);
-        let jni_descriptor = jni_c_str(&field.ty.descriptor(), self.span);
+        let jni_descriptor = jni_c_str(&field.ty.descriptor(&self.into()), self.span);
 
         let rust_field_name =
             Id::from(format!("get_{}", field.name.to_snake_case())).to_ident(self.span);
@@ -1237,10 +1237,6 @@ impl ClassInfo {
             })
             .collect()
     }
-}
-
-trait GenericExt {
-    fn to_where_clause(&self, span: Span) -> TokenStream;
 }
 
 fn jni_c_str(contents: impl Into<String>, span: Span) -> TokenStream {

--- a/macro/src/codegen.rs
+++ b/macro/src/codegen.rs
@@ -439,14 +439,14 @@ impl ClassInfo {
 
         let java_class_generics = self.class_generic_names();
 
-        let jni_descriptor = jni_c_str(constructor.descriptor(&self.into()), self.span);
+        let jni_descriptor = jni_c_str(constructor.descriptor(&self.generics_scope()), self.span);
 
         // Code to convert each input appropriately
         let prepare_inputs = self.prepare_inputs(&input_names, &constructor.argument_tys);
 
         // for debugging JVM invocation failures
         let name = Literal::string(&self.name.to_string());
-        let descriptor = Literal::string(&constructor.descriptor(&self.into()));
+        let descriptor = Literal::string(&constructor.descriptor(&self.generics_scope()));
 
         let output = quote_spanned!(self.span =>
             pub fn new(
@@ -719,7 +719,7 @@ impl ClassInfo {
             None => None,
         };
 
-        let jni_descriptor = jni_c_str(&method.descriptor(&self.into()), self.span);
+        let jni_descriptor = jni_c_str(&method.descriptor(&self.generics_scope()), self.span);
 
         // Code to convert each input appropriately
         let prepare_inputs = self.prepare_inputs(&input_names, &method.argument_tys);
@@ -920,7 +920,7 @@ impl ClassInfo {
             None => None,
         };
 
-        let jni_descriptor = jni_c_str(&method.descriptor(&self.into()), self.span);
+        let jni_descriptor = jni_c_str(&method.descriptor(&self.generics_scope()), self.span);
 
         // Code to convert each input appropriately
         let prepare_inputs = self.prepare_inputs(&input_names, &method.argument_tys);
@@ -1085,7 +1085,7 @@ impl ClassInfo {
         let jni_field_fn = sig.jni_static_field_get_fn(&field.ty)?;
 
         let jni_field = jni_c_str(&*field.name, self.span);
-        let jni_descriptor = jni_c_str(&field.ty.descriptor(&self.into()), self.span);
+        let jni_descriptor = jni_c_str(&field.ty.descriptor(&self.generics_scope()), self.span);
 
         let rust_field_name =
             Id::from(format!("get_{}", field.name.to_snake_case())).to_ident(self.span);

--- a/macro/src/java_function.rs
+++ b/macro/src/java_function.rs
@@ -1,4 +1,4 @@
- use std::{iter::once, sync::Arc};
+use std::{iter::once, sync::Arc};
 
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote_spanned;
@@ -86,7 +86,8 @@ pub fn java_function(selector: MethodSelector, input: syn::ItemFn) -> syn::Resul
 
     let rust_this_ty = driver.convert_ty(&class_info.this_ref().into())?;
     let method_name_literal = Literal::string(&selector.method_name());
-    let signature_literal = Literal::string(&driver.method_info.descriptor());
+    let signature_literal =
+        Literal::string(&driver.method_info.descriptor(&class_info.as_ref().into()));
 
     let tokens = quote_spanned!(span =>
         // Declare a function with no-mangle linkage as expected by Java.

--- a/macro/src/java_function.rs
+++ b/macro/src/java_function.rs
@@ -86,8 +86,11 @@ pub fn java_function(selector: MethodSelector, input: syn::ItemFn) -> syn::Resul
 
     let rust_this_ty = driver.convert_ty(&class_info.this_ref().into())?;
     let method_name_literal = Literal::string(&selector.method_name());
-    let signature_literal =
-        Literal::string(&driver.method_info.descriptor(&class_info.as_ref().into()));
+    let signature_literal = Literal::string(
+        &driver
+            .method_info
+            .descriptor(&class_info.as_ref().generics_scope()),
+    );
 
     let tokens = quote_spanned!(span =>
         // Declare a function with no-mangle linkage as expected by Java.

--- a/test-crates/duchess-java-tests/build.rs
+++ b/test-crates/duchess-java-tests/build.rs
@@ -68,13 +68,11 @@ fn build_java(input: &BuildFile) -> std::io::Result<()> {
         .output()?;
 
     if !output.status.success() {
-        let stdout: String =
+        let mut stdout: String =
             String::from_utf8(output.stdout).expect("Unable to parse javac output");
+        stdout.push_str(String::from_utf8(output.stderr).unwrap().as_str());
 
-        println!(
-            "cargo:warning=Failed to build {:?}: {}",
-            input.source, stdout
-        );
+        panic!("Failed to build {:?}: {}", input.source, stdout);
     }
 
     Ok(())

--- a/test-crates/duchess-java-tests/java/generics/EventKey.java
+++ b/test-crates/duchess-java-tests/java/generics/EventKey.java
@@ -1,0 +1,13 @@
+package generics;
+
+public enum EventKey implements MapKey {
+    A("abc"),
+    B("cde");
+
+    private final String name;
+
+    private EventKey(String name) {
+        this.name = name;
+    }
+
+}

--- a/test-crates/duchess-java-tests/java/generics/MapKey.java
+++ b/test-crates/duchess-java-tests/java/generics/MapKey.java
@@ -1,0 +1,5 @@
+package generics;
+
+public interface MapKey {
+
+}

--- a/test-crates/duchess-java-tests/java/generics/MapLike.java
+++ b/test-crates/duchess-java-tests/java/generics/MapLike.java
@@ -1,6 +1,8 @@
 package generics;
 
 import java.util.HashMap;
+import java.util.TreeSet;
+import java.util.Comparator;
 
 public class MapLike<TT extends MapKey> {
     public MapLike() {
@@ -13,9 +15,17 @@ public class MapLike<TT extends MapKey> {
         storage.put(key, value);
     }
 
+    // Note: although Java supports shadowing generics, Duchess currently does not.
+    public <T extends MapKey> void methodGeneric(T key, Object value) {
+        storage.put((TT) key, value);
+    }
+
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        for (TT key : storage.keySet()) {
+        TreeSet<TT> sortedKeys = new TreeSet<TT>();
+sortedKeys.addAll(storage.keySet());
+
+        for (TT key : sortedKeys) {
             sb.append(key + "=" + storage.get(key) + "\n");
         }
         return sb.toString();

--- a/test-crates/duchess-java-tests/java/generics/MapLike.java
+++ b/test-crates/duchess-java-tests/java/generics/MapLike.java
@@ -1,0 +1,23 @@
+package generics;
+
+import java.util.HashMap;
+
+public class MapLike<TT extends MapKey> {
+    public MapLike() {
+        this.storage = new HashMap<>();
+    }
+
+    private HashMap<TT, Object> storage;
+
+    public void add(TT key, Object value) {
+        storage.put(key, value);
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (TT key : storage.keySet()) {
+            sb.append(key + "=" + storage.get(key) + "\n");
+        }
+        return sb.toString();
+    }
+}

--- a/test-crates/duchess-java-tests/tests/ui/examples/generics.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/generics.rs
@@ -1,0 +1,29 @@
+//@run
+use duchess::{java, prelude::*};
+
+duchess::java_package! {
+    package generics;
+
+    public final class generics.EventKey {
+        public static final generics.EventKey A;
+    }
+
+    interface generics.MapKey { * }
+
+
+    public class generics.MapLike<TT extends generics.MapKey> {
+        public generics.MapLike();
+        public void add(TT, java.lang.Object);
+    }
+}
+
+fn main() {
+    use generics::*;
+    let base = EventKey::get_a();
+    let event = MapLike::<EventKey>::new().execute().unwrap();
+    event.add(base, "value").execute().unwrap();
+    assert_eq!(
+        event.to_string().execute().unwrap(),
+        Some("A=value\n".to_string())
+    );
+}

--- a/test-crates/duchess-java-tests/tests/ui/examples/generics.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/generics.rs
@@ -4,8 +4,9 @@ use duchess::{java, prelude::*};
 duchess::java_package! {
     package generics;
 
-    public final class generics.EventKey {
+    public final class generics.EventKey implements generics.MapKey {
         public static final generics.EventKey A;
+        public static final generics.EventKey B;
     }
 
     interface generics.MapKey { * }
@@ -14,6 +15,7 @@ duchess::java_package! {
     public class generics.MapLike<TT extends generics.MapKey> {
         public generics.MapLike();
         public void add(TT, java.lang.Object);
+        public <T extends generics.MapKey> void methodGeneric(T, java.lang.Object);
     }
 }
 
@@ -21,9 +23,13 @@ fn main() {
     use generics::*;
     let base = EventKey::get_a();
     let event = MapLike::<EventKey>::new().execute().unwrap();
-    event.add(base, "value").execute().unwrap();
+    event.add(base, "value-a").execute().unwrap();
+    event
+        .method_generic::<EventKey>(EventKey::get_b(), "value-b")
+        .execute()
+        .unwrap();
     assert_eq!(
         event.to_string().execute().unwrap(),
-        Some("A=value\n".to_string())
+        Some("A=value-a\nB=value-b\n".to_string())
     );
 }


### PR DESCRIPTION
Fixes: https://github.com/duchess-rs/duchess/issues/42
Fixes: https://github.com/duchess-rs/duchess/issues/149

Generics were not code generated properly. They should actually refer to the first class in the list of extending classes. This introduces `GenericsScope` to keep track of where generics were defined when creating descriptors.