### PR TITLE
Add `must_use` to JvmOp

### DIFF
--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -33,6 +33,7 @@ mod test;
 /// *Eventual goal:* Each call to `execute` represents a single crossing
 /// over into the JVM, so the more you can chain together your jvm-ops,
 /// the better.
+#[must_use = "JvmOps do nothing unless you call `.execute()"]
 pub trait JvmOp: Copy {
     type Output<'jvm>;
 

--- a/test-crates/duchess-java-tests/tests/ui/examples/log.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/log.rs
@@ -32,7 +32,7 @@ fn main() -> duchess::Result<()> {
     let logger = log::Logger::new().execute()?;
 
     let timestamp = java::util::Date::new();
-    timestamp.set_time(0i64);
+    timestamp.set_time(0i64).execute().unwrap();
 
     logger
         .add_event(

--- a/test-crates/duchess-java-tests/tests/ui/must_use_jvmop.rs
+++ b/test-crates/duchess-java-tests/tests/ui/must_use_jvmop.rs
@@ -1,0 +1,9 @@
+use duchess::java;
+
+#[deny(unused_must_use)]
+fn main() -> duchess::Result<()> {
+    let timestamp = java::util::Date::new();
+    timestamp.set_time(0i64); //~ ERROR: unused implementer of `JvmOp` that must be used
+
+    Ok(())
+}


### PR DESCRIPTION
It's very easy to accidentally avoid calling execute because of how Rust-like Duchess makes calling Java code. As an example, one of our own examples failed to call execute!