### PR TITLE
Add test for null String

### DIFF
--- a/book/src/call_java_from_rust.md
+++ b/book/src/call_java_from_rust.md
@@ -118,6 +118,8 @@ f.consume_widget(j).execute();
 //               ^ like this!
 ```
 
+See [tests](https://github.com/duchess-rs/duchess/blob/main/test-crates/duchess-java-tests/tests/ui/passing_null_values.rs) for more examples.
+
 ## Launching the JVM
 
 Note that to call methods on the JVM, we first had to start it. You do that via `duchess::Jvm::with`. This method will launch a JVM if it hasn't already started and attach it to the current thread. OpenJDK only supports one JVM per process, so the JVM is global. You can learn more about launching a JVM (including how to set options like the classpath) in the [JVM chapter of the reference](./jvm.md).

--- a/test-crates/duchess-java-tests/java/take_null/TakeNullRecord.java
+++ b/test-crates/duchess-java-tests/java/take_null/TakeNullRecord.java
@@ -1,0 +1,11 @@
+package take_null;
+
+public record TakeNullRecord(
+    String field
+) {
+    public boolean isNull() {
+        return this.field == null;
+    }
+}
+
+

--- a/test-crates/duchess-java-tests/tests/ui/passing_null_values.rs
+++ b/test-crates/duchess-java-tests/tests/ui/passing_null_values.rs
@@ -21,5 +21,10 @@ pub fn main() -> duchess::Result<()> {
     let is_null = take_null.take_null_string(duchess::Null).execute()?;
     assert!(is_null);
 
+    let is_null = take_null
+        .take_null_string(&None::<Java<java::lang::String>>)
+        .execute()?;
+    assert!(is_null);
+
     Ok(())
 }

--- a/test-crates/duchess-java-tests/tests/ui/passing_null_values.rs
+++ b/test-crates/duchess-java-tests/tests/ui/passing_null_values.rs
@@ -5,6 +5,13 @@ duchess::java_package! {
     package take_null;
 
     public class TakeNull { * }
+    public class TakeNullRecord { * }
+}
+
+#[derive(duchess::ToJava)]
+#[java(take_null.TakeNullRecord)]
+struct TakeNullRecord {
+    field: Option<String>
 }
 
 pub fn main() -> duchess::Result<()> {
@@ -24,6 +31,22 @@ pub fn main() -> duchess::Result<()> {
     let is_null = take_null
         .take_null_string(&None::<Java<java::lang::String>>)
         .execute()?;
+    assert!(is_null);
+
+    let take_null_record = TakeNullRecord {
+        field: Some(String::from("mystring")),
+    };
+
+    let java = take_null_record.to_java().execute().unwrap().unwrap();
+    let is_null = java.is_null().execute()?;
+    assert!(!is_null);
+
+    let take_null_record = TakeNullRecord {
+        field: None,
+    };
+
+    let java = take_null_record.to_java().execute().unwrap().unwrap();
+    let is_null = java.is_null().execute()?;
     assert!(is_null);
 
     Ok(())


### PR DESCRIPTION
Add a simple test for java `String` is `null` from Rust None `Option`.