### PR TITLE
Update thread model to include new understandings

### DIFF
--- a/book/src/safety.md
+++ b/book/src/safety.md
@@ -11,7 +11,7 @@ However, there are edge cases that can "void" this guarantee and which Duchess c
 
 Duchess will guarantee memory safety within your crate, but there are two conditions that it cannot by itself guarantee:
 * Duchess does not "sandbox" or "make safe" the Java code it executes. You MUST ensure that Java code being invoked is safe and trusted. You MUST NOT invoke untrusted Java code with Duchess.
-* **You must SHOULD with the same Java class files that you will use when you deploy:**
+* **You SHOULD with the same Java class files that you will use when you deploy:**
     * We believe that no loss of memory-safety is possible if incorrect `.class` files are loaded, however, if interfaces change you will experience failures at runtime.
 * **You must be careful when mixing Duchess with other Rust JNI libraries:** (e.g., the [jni crate](https://crates.io/crates/jni) or [robusta_jni](https://crates.io/crates/robusta_jni))
     * For the most part, interop between Duchess and other JNI crates should be no problem. But there are some particular things that can cause issues:

--- a/book/src/safety.md
+++ b/book/src/safety.md
@@ -10,10 +10,9 @@ However, there are edge cases that can "void" this guarantee and which Duchess c
 ## Memory safety requirements
 
 Duchess will guarantee memory safety within your crate, but there are two conditions that it cannot by itself guarantee:
-
-* **You must build with the same Java class files that you will use when you deploy:**
-    * Part of how Duchess guarantees is safety is by reflecting on `.class` files at build time.
-    * If you build against one set of class files then deploy with another, 
+* Duchess does not "sandbox" or "make safe" the Java code it executes. You MUST ensure that Java code being invoked is safe and trusted. You MUST NOT invoke untrusted Java code with Duchess.
+* **You must SHOULD with the same Java class files that you will use when you deploy:**
+    * We believe that no loss of memory-safety is possible if incorrect `.class` files are loaded, however, if interfaces change you will experience failures at runtime.
 * **You must be careful when mixing Duchess with other Rust JNI libraries:** (e.g., the [jni crate](https://crates.io/crates/jni) or [robusta_jni](https://crates.io/crates/robusta_jni))
     * For the most part, interop between Duchess and other JNI crates should be no problem. But there are some particular things that can cause issues:
         * The JVM cannot be safely started from multiple threads at once.


### PR DESCRIPTION
After some investigation, there does not seem to be any loss of safety possible when incorrect `.class` files are used.