### PR TITLE
Add JMX APIs to Java prelude

### DIFF
--- a/src/java.rs
+++ b/src/java.rs
@@ -343,6 +343,7 @@ mod auto {
 
         public class ManagementFactory {
             public static java.util.List<java.lang.management.GarbageCollectorMXBean> getGarbageCollectorMXBeans();
+            public static java.util.List<java.lang.management.MemoryPoolMXBean> getMemoryPoolMXBeans();
             public static java.lang.management.MemoryMXBean getMemoryMXBean();
         }
 
@@ -353,7 +354,15 @@ mod auto {
             public abstract boolean isVerbose();
             public abstract void setVerbose(boolean);
             public abstract void gc();
-          }
+        }
+
+        public interface java.lang.management.MemoryPoolMXBean {
+            public abstract java.lang.String getName();
+            public abstract java.lang.management.MemoryType getType();
+            public abstract java.lang.management.MemoryUsage getUsage();
+            public abstract java.lang.management.MemoryUsage getCollectionUsage();
+            public abstract java.lang.management.MemoryUsage getPeakUsage();
+        }
 
         public class java.lang.management.MemoryUsage {
             private final long init;

--- a/src/java.rs
+++ b/src/java.rs
@@ -343,7 +343,43 @@ mod auto {
 
         public class ManagementFactory {
             public static java.util.List<java.lang.management.GarbageCollectorMXBean> getGarbageCollectorMXBeans();
+            public static java.lang.management.MemoryMXBean getMemoryMXBean();
         }
+
+        public interface java.lang.management.MemoryMXBean {
+            public abstract int getObjectPendingFinalizationCount();
+            public abstract java.lang.management.MemoryUsage getHeapMemoryUsage();
+            public abstract java.lang.management.MemoryUsage getNonHeapMemoryUsage();
+            public abstract boolean isVerbose();
+            public abstract void setVerbose(boolean);
+            public abstract void gc();
+          }
+
+        public class java.lang.management.MemoryUsage {
+            private final long init;
+            private final long used;
+            private final long committed;
+            private final long max;
+            public java.lang.management.MemoryUsage(long, long, long, long);
+            public long getInit();
+            public long getUsed();
+            public long getCommitted();
+            public long getMax();
+            public java.lang.String toString();
+        }
+
+        public final class java.lang.management.MemoryType {
+            public static final java.lang.management.MemoryType HEAP;
+            public static final java.lang.management.MemoryType NON_HEAP;
+            private final java.lang.String description;
+            private static final java.lang.management.MemoryType[] $VALUES;
+            public static java.lang.management.MemoryType[] values();
+            public static java.lang.management.MemoryType valueOf(java.lang.String);
+            private java.lang.management.MemoryType(java.lang.String);
+            public java.lang.String toString();
+            private static java.lang.management.MemoryType[] $values();
+            static {};
+          }
     }
 }
 

--- a/src/java.rs
+++ b/src/java.rs
@@ -328,6 +328,22 @@ mod auto {
             // public int compareTo(java.lang.Object);
         }
 
+        package java.lang.management;
+
+        public interface java.lang.management.MemoryManagerMXBean {
+            public abstract java.lang.String getName();
+            public abstract boolean isValid();
+            public abstract java.lang.String[] getMemoryPoolNames();
+        }
+
+        interface GarbageCollectorMXBean extends java.lang.management.MemoryManagerMXBean {
+            public long getCollectionCount();
+            public long getCollectionTime();
+        }
+
+        public class ManagementFactory {
+            public static java.util.List<java.lang.management.GarbageCollectorMXBean> getGarbageCollectorMXBeans();
+        }
     }
 }
 

--- a/test-crates/duchess-java-tests/tests/ui/examples/memory_usage.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/memory_usage.rs
@@ -1,0 +1,18 @@
+//@run
+
+fn main() {
+    use duchess::prelude::*;
+    use java::lang::management::ManagementFactory;
+    let memory_bean = ManagementFactory::get_memory_mx_bean();
+    let heap_usage = memory_bean
+        .get_heap_memory_usage()
+        .get_used()
+        .execute()
+        .expect("failed to load usage");
+    let other_usage = memory_bean
+        .get_non_heap_memory_usage()
+        .get_used()
+        .execute()
+        .expect("failed to load usage");
+    println!("total memory usage: {}", heap_usage + other_usage);
+}


### PR DESCRIPTION
Currently, there is not straightforward way of defining a `java.*` package outside of Duchess