### PR TITLE
Add in checks for the type of Java Class/Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/duchess-rs/duchess"
 homepage = "https://duchess-rs.github.io/duchess/"
@@ -18,7 +18,7 @@ readme = "README.md"
 
 [dependencies]
 derive_more = "0.99.17"
-duchess-macro = { path = "macro", version = "0.2.1" }
+duchess-macro = { path = "macro", version = "0.3.0" }
 jni-sys = "0.3.0"
 cesu8 = "1.1.0"
 once_cell = "1.17.1"

--- a/macro/src/check.rs
+++ b/macro/src/check.rs
@@ -39,6 +39,13 @@ impl ClassInfo {
             ));
         };
 
+        if self.kind != info.kind {
+            push_error_message(format!(
+                "class `{}` should be type `{:?}`",
+                self.name, info.kind
+            ));
+        }
+
         // We always allow people to elide generics, in which case
         // they are mirroring the "erased" version of the class.
         //

--- a/macro/src/check.rs
+++ b/macro/src/check.rs
@@ -41,8 +41,9 @@ impl ClassInfo {
 
         if self.kind != info.kind {
             push_error_message(format!(
-                "class `{}` should be type `{:?}`",
-                self.name, info.kind
+                "class `{}` should be type `{}`",
+                self.name,
+                format!("{:?}", info.kind).to_lowercase()
             ));
         }
 

--- a/macro/src/reflect.rs
+++ b/macro/src/reflect.rs
@@ -74,7 +74,16 @@ impl JavaPackage {
                 ClassDecl::Reflected(c) => {
                     let dot_id = self.make_absolute_dot_id(c.span, &c.name)?;
                     let info = reflector.reflect(&dot_id, c.span)?;
-                    (dot_id, info.clone())
+
+                    // We copy over the span and kind for proper error specification and error checking
+                    (
+                        dot_id,
+                        Arc::new(ClassInfo {
+                            span: c.span,
+                            kind: c.kind,
+                            ..(*info).clone()
+                        }),
+                    )
                 }
                 ClassDecl::Specified(c) => {
                     let dot_id = self.make_absolute_dot_id(c.span, &c.name)?;

--- a/test-crates/duchess-java-tests/tests/ui/examples/log.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/log.rs
@@ -23,9 +23,9 @@ duchess::java_package! {
 
     class Event { * }
     class Logger { * }
-    class NameStep { * }
-    class TimeStep { * }
-    class BuildStep { * }
+    interface NameStep { * }
+    interface TimeStep { * }
+    interface BuildStep { * }
 }
 
 fn main() -> duchess::Result<()> {

--- a/test-crates/duchess-java-tests/tests/ui/examples/log_global_ref_and_chained_calls.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/log_global_ref_and_chained_calls.rs
@@ -23,9 +23,9 @@ duchess::java_package! {
 
     class Event { * }
     class Logger { * }
-    class NameStep { * }
-    class TimeStep { * }
-    class BuildStep { * }
+    interface NameStep { * }
+    interface TimeStep { * }
+    interface BuildStep { * }
 }
 
 fn main() -> duchess::Result<()> {

--- a/test-crates/duchess-java-tests/tests/ui/examples/log_global_ref_and_two_calls.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/log_global_ref_and_two_calls.rs
@@ -23,9 +23,9 @@ duchess::java_package! {
 
     class Event { * }
     class Logger { * }
-    class NameStep { * }
-    class TimeStep { * }
-    class BuildStep { * }
+    interface NameStep { * }
+    interface TimeStep { * }
+    interface BuildStep { * }
 }
 
 fn main() -> duchess::Result<()> {

--- a/test-crates/duchess-java-tests/tests/ui/examples/log_local_ref_and_two_calls.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/log_local_ref_and_two_calls.rs
@@ -23,9 +23,9 @@ duchess::java_package! {
 
     class Event { * }
     class Logger { * }
-    class NameStep { * }
-    class TimeStep { * }
-    class BuildStep { * }
+    interface NameStep { * }
+    interface TimeStep { * }
+    interface BuildStep { * }
 }
 
 fn main() -> duchess::Result<()> {

--- a/test-crates/duchess-java-tests/tests/ui/examples/log_one_big_call.rs
+++ b/test-crates/duchess-java-tests/tests/ui/examples/log_one_big_call.rs
@@ -23,9 +23,9 @@ duchess::java_package! {
 
     class Event { * }
     class Logger { * }
-    class NameStep { * }
-    class TimeStep { * }
-    class BuildStep { * }
+    interface NameStep { * }
+    interface TimeStep { * }
+    interface BuildStep { * }
 }
 
 fn main() -> duchess::Result<()> {

--- a/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_reflected.rs
+++ b/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_reflected.rs
@@ -1,0 +1,7 @@
+duchess::java_package! {
+    package exceptions;
+
+    public interface DifferentException { * } //~ ERROR: error in class
+}
+
+fn main() {}

--- a/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_reflected.stderr
+++ b/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_reflected.stderr
@@ -1,0 +1,8 @@
+error: error in class `exceptions.DifferentException`: class `exceptions.DifferentException` should be type `Class`
+ --> tests/ui/interface_class_mismatch_reflected.rs:4:5
+  |
+4 |     public interface DifferentException { * }
+  |     ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_reflected.stderr
+++ b/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_reflected.stderr
@@ -1,4 +1,4 @@
-error: error in class `exceptions.DifferentException`: class `exceptions.DifferentException` should be type `Class`
+error: error in class `exceptions.DifferentException`: class `exceptions.DifferentException` should be type `class`
  --> tests/ui/interface_class_mismatch_reflected.rs:4:5
   |
 4 |     public interface DifferentException { * }

--- a/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_specified.rs
+++ b/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_specified.rs
@@ -1,0 +1,7 @@
+duchess::java_package! {
+    package exceptions;
+
+    public interface ThrowExceptions { } //~ ERROR: error in class
+}
+
+fn main() {}

--- a/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_specified.stderr
+++ b/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_specified.stderr
@@ -1,0 +1,8 @@
+error: error in class `exceptions.ThrowExceptions`: class `exceptions.ThrowExceptions` should be type `Class`
+ --> tests/ui/interface_class_mismatch_specified.rs:4:5
+  |
+4 |     public interface ThrowExceptions { }
+  |     ^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_specified.stderr
+++ b/test-crates/duchess-java-tests/tests/ui/interface_class_mismatch_specified.stderr
@@ -1,4 +1,4 @@
-error: error in class `exceptions.ThrowExceptions`: class `exceptions.ThrowExceptions` should be type `Class`
+error: error in class `exceptions.ThrowExceptions`: class `exceptions.ThrowExceptions` should be type `class`
  --> tests/ui/interface_class_mismatch_specified.rs:4:5
   |
 4 |     public interface ThrowExceptions { }

--- a/test-crates/viper/src/lib.rs
+++ b/test-crates/viper/src/lib.rs
@@ -4,7 +4,7 @@ duchess::java_package! {
 
     package scala;
     class AnyVal { * }
-    class Function1 {}
+    interface Function1 {}
     class Tuple2<T1, T2> {}
     class Option<A> {}
     class Some<A> extends scala.Option<A> {}
@@ -37,7 +37,7 @@ duchess::java_package! {
     class "NoTrafos$" implements viper.silver.ast.ErrorTrafo {
         public static viper.silver.ast."NoTrafos$" "MODULE$";
     }
-    class ExtensionMember {}
+    interface ExtensionMember {}
     class Field {}
     class Function {}
     class Int {}
@@ -68,7 +68,7 @@ duchess::java_package! {
     interface Position {}
 
     package viper.silver.frontend;
-    class SilFrontend {}
+    interface SilFrontend {}
 
     package viper.silver.reporter;
     interface Reporter {}


### PR DESCRIPTION
Works for both fully reflected classes and for specified classes. Added UI tests for both cases, and updated other portions where needed to specify the correct type of Java import.

For Reflected classes, fixed an error in specifying the span and kind of the class. Previously, they took the span of the reflection cache, which meant that the error could confusingly point to the main `java_package!` macro invocation.

Fixes #67.