### PR TITLE
Add support for multiple Errors to surface

### DIFF
--- a/macro/src/check.rs
+++ b/macro/src/check.rs
@@ -14,11 +14,12 @@ impl RootMap {
             ci.check(self, reflector, &mut |e| errors.push(e))?;
         }
 
-        // FIXME: support multiple errors
-        if let Some(e) = errors.pop() {
-            Err(e)
-        } else {
-            Ok(())
+        match errors.into_iter().reduce(|mut error, next| {
+            error.combine(next);
+            error
+        }) {
+            Some(e) => Err(e),
+            None => Ok(()),
         }
     }
 }

--- a/test-crates/duchess-java-tests/tests/ui/duplicate_extends.rs
+++ b/test-crates/duchess-java-tests/tests/ui/duplicate_extends.rs
@@ -1,7 +1,8 @@
 duchess::java_package! {
     package log;
 
-    public class log.Builder extends java.lang.Object, java.lang.Object {} //~ ERROR: duplicate reference
+    public class log.Builder extends java.lang.Object, java.lang.Object {} //~ ERROR: declared interface
+                                     //~^ ERROR: duplicate reference
 }
 
 fn main() {}

--- a/test-crates/duchess-java-tests/tests/ui/duplicate_extends.stderr
+++ b/test-crates/duchess-java-tests/tests/ui/duplicate_extends.stderr
@@ -1,8 +1,14 @@
+error: error in class `log.Builder`: declared interface `java.lang.Object` not found in the reflected superclasses ()
+ --> tests/ui/duplicate_extends.rs:4:5
+  |
+4 |     public class log.Builder extends java.lang.Object, java.lang.Object {}
+  |     ^^^^^^
+
 error: error in class `log.Builder`: duplicate reference in 'extends' to 'java.lang.Object'
  --> tests/ui/duplicate_extends.rs:4:5
   |
 4 |     public class log.Builder extends java.lang.Object, java.lang.Object {}
   |     ^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 

--- a/test-crates/duchess-java-tests/tests/ui/duplicate_implements.rs
+++ b/test-crates/duchess-java-tests/tests/ui/duplicate_implements.rs
@@ -1,6 +1,8 @@
 duchess::java_package! {
     package log;
 
+    public interface log.BuildStep { * }
+
     public class log.Builder implements log.BuildStep, log.BuildStep {} //~ ERROR: duplicate reference
 }
 


### PR DESCRIPTION
Ensures that all errors are propagated to users of the library, to be able to be fixed in one go.

Very few UI tests are broken by this, updated the two that needed updates.