### PR TITLE
Java to rust exceptions

### DIFF
--- a/book/src/threat_model.md
+++ b/book/src/threat_model.md
@@ -152,6 +152,19 @@ The [JNI manual documents](https://docs.oracle.com/javase/8/docs/technotes/guide
     * invokes [`GetStringLength`](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetStringLength) — infallible
     * invokes [`GetStringUTFLength`](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetStringUTFLength) — infallible
     * invokes [`GetStringUTFRegion`](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetStringUTFRegion) with known-valid bounds
+* `jvm.rs`
+    * invokes [`Throw`](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#Throw) - Raises an exception for the caller to handle
+    * invokes [`ThrowNew`](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#ThrowNew) - Raises an exception for the caller to handle
+
+### Usage of Throw and ThrowNew
+
+> The native method can choose to return immediately, causing the exception to be thrown in the Java code that initiated the native method call.
+
+[Citation.](https://docs.oracle.com/en/java/javase/17/docs/specs/jni/design.html#exception-handling)
+
+**Outcome of nonadherence:** Undefined behavior.
+
+**How Duchess avoids this:** Throw and ThrowNew are invoked from the `java_function` macro as part of `native_function_returning_object` and `native_function_returning_scalar`. After duchess raises the exception, no more JNI calls are made and null or 0 is returned forcing the Java caller to handle the exception.
 
 ### Clear exceptions before invoking other JNI calls
 

--- a/src/java.rs
+++ b/src/java.rs
@@ -54,6 +54,10 @@ mod auto {
             public java.lang.RuntimeException();
         }
 
+        public class java.lang.NullPointerException extends java.lang.RuntimeException {
+            public java.lang.NullPointerException();
+        }
+
         // NB: In Java, this is `Class<T>`, but we model it as the erased version
         // `Class`. This is beacuse there are a lot of methods, including some that we would
         // like to model such as `arrayType()`, that return a `Class<?>`, and we cannot model

--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -15,7 +15,7 @@ use crate::{
 use std::{
     any::Any,
     collections::HashMap,
-    ffi::{c_char, c_void, CStr},
+    ffi::{c_char, c_void, CStr, CString},
     fmt::Display,
     panic::AssertUnwindSafe,
 };
@@ -135,6 +135,63 @@ fn get_or_default_init_jvm() -> crate::Result<JvmPtr> {
     }
 }
 
+fn throw_java_runtime_exception(env: EnvPtr<'_>, message: &str) {
+    let mut jvm = Jvm(env);
+
+    let runtime_exception_clazz = crate::java::lang::RuntimeException::class(&mut jvm)
+        .expect("java/lang/RuntimeException not found");
+
+    let encoded = cesu8::to_java_cesu8(message);
+    // SAFETY: cesu8 encodes interior nul bytes as 0xC080
+    let c_string = unsafe { CString::from_vec_unchecked(encoded.into_owned()) };
+
+    unsafe {
+        env.invoke_unchecked(
+            |env| env.ThrowNew,
+            |jni, f| {
+                f(
+                    jni,
+                    runtime_exception_clazz.as_raw().as_ptr(),
+                    c_string.as_ptr(),
+                )
+            },
+        );
+    };
+}
+
+fn error_to_java_exception(env: EnvPtr<'_>, error: Error<Local<Throwable>>) {
+    // SAFETY: invoke_unchecked is used here to raise an exception. The exception is not
+    // cleared to force the caller to handle the exception
+    let _ = match error {
+        Error::Thrown(t) => unsafe {
+            env.invoke_unchecked(|env| env.Throw, |env, f| f(env, t.as_raw().as_ptr()));
+        },
+        Error::JvmInternal(s) => {
+            throw_java_runtime_exception(env, &s);
+        }
+        Error::NullDeref => unsafe {
+            env.invoke_unchecked(
+                |env| env.ThrowNew,
+                |jni, f| {
+                    let mut jvm = Jvm(env);
+                    let npe_clazz = crate::java::lang::NullPointerException::class(&mut jvm);
+                    f(
+                        jni,
+                        npe_clazz
+                            .expect("java/lang/NullPointerException not found")
+                            .as_raw()
+                            .as_ptr(),
+                        std::ptr::null(),
+                    )
+                },
+            );
+        },
+        e => {
+            throw_java_runtime_exception(env, &format!("{}", e));
+        }
+    };
+}
+
 /// Invoked as the body from a JNI native function when it is called by the JVM.
 /// Initializes the environment and invokes `op`. Converts the result into a java
 /// object and returns it. Caller should then return this to the JVM.
@@ -161,12 +218,15 @@ where
             match obj {
                 Ok(Some(p)) => p.into_raw().as_ptr(),
                 Ok(None) => std::ptr::null_mut(),
-                Err(e) => todo!("convert from exception `{e:?}` into java exception"),
+                Err(e) => {
+                    error_to_java_exception(env, e);
+                    std::ptr::null_mut()
+                }
             }
         }
 
         Err(e) => {
-            rust_panic_to_java_exception(e);
+            let panic_as_err = rust_panic_to_java_exception(env, e);
             std::ptr::null_mut()
         }
     };
@@ -193,7 +253,7 @@ where
     let result = match std::panic::catch_unwind(AssertUnwindSafe(|| op())) {
         Ok(result) => result,
         Err(e) => {
-            rust_panic_to_java_exception(e);
+            rust_panic_to_java_exception(env, e);
             R::default()
         }
     };
@@ -221,8 +281,17 @@ unsafe fn init_jvm_from_native_function(env: EnvPtr<'_>) -> Jvm<'_> {
     Jvm(env)
 }
 
-fn rust_panic_to_java_exception(_panic: Box<dyn Any + Send + 'static>) {
-    todo!("rust_panic_to_java_exception")
+fn rust_panic_to_java_exception(env: EnvPtr<'_>, panic: Box<dyn Any + Send + 'static>) {
+    // The documentation suggests that it will *usually* be a str or String.
+    let message = if let Some(s) = panic.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic!".to_string()
+    };
+
+    throw_java_runtime_exception(env, &message);
 }
 
 /// Get the global [`JvmPtr`] assuming that the JVM has already been initialized. Expected to be used with values

--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -156,7 +156,7 @@ fn throw_java_runtime_exception(env: EnvPtr<'_>, message: &str) {
     };
 }
 
-fn error_to_java_exception(env: EnvPtr<'_>, error: Error<Local<'_ Throwable>>) {
+fn error_to_java_exception(env: EnvPtr<'_>, error: Error<Local<'_, Throwable>>) {
     // SAFETY: invoke_unchecked is used here to raise an exception. The exception is not
     // cleared to force the caller to handle the exception
     let _ = match error {

--- a/src/jvm.rs
+++ b/src/jvm.rs
@@ -156,7 +156,7 @@ fn throw_java_runtime_exception(env: EnvPtr<'_>, message: &str) {
     };
 }
 
-fn error_to_java_exception(env: EnvPtr<'_>, error: Error<Local<Throwable>>) {
+fn error_to_java_exception(env: EnvPtr<'_>, error: Error<Local<'_ Throwable>>) {
     // SAFETY: invoke_unchecked is used here to raise an exception. The exception is not
     // cleared to force the caller to handle the exception
     let _ = match error {

--- a/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_initiated_exceptions/JavaRustExceptions.java
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_initiated_exceptions/JavaRustExceptions.java
@@ -1,0 +1,57 @@
+//@check-pass
+
+package java_rust_initiated_exceptions;
+
+public class JavaRustExceptions {
+    native String raiseNPE();
+    native String raiseSliceTooLong();
+    native String raiseJvmInternal();
+
+    public static void expectNPE(JavaRustExceptions test) {
+        try {
+            test.raiseNPE();
+        } catch (NullPointerException e) {
+            return;
+        }
+
+        throw new RuntimeException("NullPointerException not caught");
+    }
+
+    public static void expectSliceTooLong(JavaRustExceptions test) {
+        String message = "no exception thrown";
+        try {
+            test.raiseSliceTooLong();
+        } catch (RuntimeException e) {
+            message = e.getMessage();
+            return;
+        }
+
+        if (!message.contains("slice was too long")) {
+            throw new RuntimeException("Caught no exception or the wrong exception: " + message);
+        }
+    }
+
+    public static void expectJvmInternal(JavaRustExceptions test) {
+        String message = "no exception thrown";
+        try {
+            test.raiseJvmInternal();
+        } catch (RuntimeException e) {
+            message = e.getMessage();
+            return;
+        }
+
+        if (message != "JvmInternal") {
+            throw new RuntimeException("Caught no exception or the wrong exception: " + message);
+        }
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("java_rust_initiated_exceptions");
+        JavaRustExceptions test = new JavaRustExceptions();
+
+        expectNPE(test);
+        expectSliceTooLong(test);
+        expectJvmInternal(test);
+    }
+
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_initiated_exceptions/JavaRustExceptions.java
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_initiated_exceptions/JavaRustExceptions.java
@@ -6,6 +6,7 @@ public class JavaRustExceptions {
     native String raiseNPE();
     native String raiseSliceTooLong();
     native String raiseJvmInternal();
+    native String panic();
 
     public static void expectNPE(JavaRustExceptions test) {
         try {
@@ -23,7 +24,6 @@ public class JavaRustExceptions {
             test.raiseSliceTooLong();
         } catch (RuntimeException e) {
             message = e.getMessage();
-            return;
         }
 
         if (!message.contains("slice was too long")) {
@@ -37,10 +37,22 @@ public class JavaRustExceptions {
             test.raiseJvmInternal();
         } catch (RuntimeException e) {
             message = e.getMessage();
-            return;
         }
 
-        if (message != "JvmInternal") {
+        if (!message.equals("JvmInternal")) {
+            throw new RuntimeException("Caught no exception or the wrong exception: " + message);
+        }
+    }
+
+    public static void expectPanicIsRuntimeException(JavaRustExceptions test) {
+        String message = "no exception thrown";
+        try {
+            test.panic();
+        } catch (RuntimeException e) {
+            message = e.getMessage();
+        }
+
+        if (!message.equals("RUST PANIC!")) {
             throw new RuntimeException("Caught no exception or the wrong exception: " + message);
         }
     }
@@ -52,6 +64,7 @@ public class JavaRustExceptions {
         expectNPE(test);
         expectSliceTooLong(test);
         expectJvmInternal(test);
+        expectPanicIsRuntimeException(test);
     }
 
 }

--- a/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_java_exception/JavaRustJavaException.java
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_java_exception/JavaRustJavaException.java
@@ -1,0 +1,27 @@
+//@check-pass
+
+package java_rust_java_exception;
+
+public class JavaRustJavaException {
+    native String rustFunction();
+
+    public String javaFunction() {
+        throw new RuntimeException("Exception from `javaFunction`");
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("java_rust_java_exception");
+        JavaRustJavaException test = new JavaRustJavaException();
+        String message = "no exception thrown";
+        try {
+            test.rustFunction();
+        } catch (RuntimeException e) {
+            message = e.getMessage();
+        }
+
+        if (message != "Exception from `javaFunction`") {
+            throw new RuntimeException("Caught no exception or the wrong exception: " + message);
+        }
+    }
+
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_java_exception/JavaRustJavaNPE.java
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/java/java_rust_java_exception/JavaRustJavaNPE.java
@@ -1,0 +1,24 @@
+//@check-pass
+
+package java_rust_java_exception;
+
+public class JavaRustJavaNPE {
+    native String rustFunction();
+
+    public String javaFunction() {
+        throw new NullPointerException();
+    }
+
+    public static void main(String[] args) {
+        System.loadLibrary("java_rust_java_npe");
+        JavaRustJavaNPE test = new JavaRustJavaNPE();
+        try {
+            test.rustFunction();
+        } catch (NullPointerException e) {
+            return;
+        }
+
+        throw new RuntimeException("Did not catch NullPointerException");
+    }
+
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_initiated_exceptions.rs
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_initiated_exceptions.rs
@@ -28,3 +28,10 @@ fn raiseJvmInternal(
 ) -> duchess::Result<Java<java::lang::String>> {
     Err(duchess::Error::JvmInternal("JvmInternal".to_string()))
 }
+
+#[duchess::java_function(java_rust_initiated_exceptions.JavaRustExceptions::panic)]
+fn panic(
+    this: &java_rust_initiated_exceptions::JavaRustExceptions,
+) -> duchess::Result<Java<java::lang::String>> {
+    panic!("RUST PANIC!");
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_initiated_exceptions.rs
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_initiated_exceptions.rs
@@ -1,0 +1,30 @@
+//@check-pass
+
+use duchess::prelude::*;
+
+duchess::java_package! {
+    package java_rust_initiated_exceptions;
+
+    public class java_rust_initiated_exceptions.JavaRustExceptions { * }
+}
+
+#[duchess::java_function(java_rust_initiated_exceptions.JavaRustExceptions::raiseNPE)]
+fn raiseNPE(
+    this: &java_rust_initiated_exceptions::JavaRustExceptions,
+) -> duchess::Result<Java<java::lang::String>> {
+    Err(duchess::Error::NullDeref)
+}
+
+#[duchess::java_function(java_rust_initiated_exceptions.JavaRustExceptions::raiseSliceTooLong)]
+fn raiseSliceTooLong(
+    this: &java_rust_initiated_exceptions::JavaRustExceptions,
+) -> duchess::Result<Java<java::lang::String>> {
+    Err(duchess::Error::SliceTooLong(5))
+}
+
+#[duchess::java_function(java_rust_initiated_exceptions.JavaRustExceptions::raiseJvmInternal)]
+fn raiseJvmInternal(
+    this: &java_rust_initiated_exceptions::JavaRustExceptions,
+) -> duchess::Result<Java<java::lang::String>> {
+    Err(duchess::Error::JvmInternal("JvmInternal".to_string()))
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_java_exception.rs
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_java_exception.rs
@@ -1,0 +1,16 @@
+//@check-pass
+
+use duchess::prelude::*;
+
+duchess::java_package! {
+    package java_rust_java_exception;
+
+    public class java_rust_java_exception.JavaRustJavaException { * }
+}
+
+#[duchess::java_function(java_rust_java_exception.JavaRustJavaException::rustFunction)]
+fn rust_function(
+    this: &java_rust_java_exception::JavaRustJavaException,
+) -> duchess::Result<Java<java::lang::String>> {
+    Ok(this.java_function().assert_not_null().execute()?)
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_java_npe.rs
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/java_rust_java_npe.rs
@@ -1,0 +1,16 @@
+//@check-pass
+
+use duchess::prelude::*;
+
+duchess::java_package! {
+    package java_rust_java_exception;
+
+    public class java_rust_java_exception.JavaRustJavaNPE { * }
+}
+
+#[duchess::java_function(java_rust_java_exception.JavaRustJavaNPE::rustFunction)]
+fn rust_function(
+    this: &java_rust_java_exception::JavaRustJavaNPE,
+) -> duchess::Result<Java<java::lang::String>> {
+    Ok(this.java_function().assert_not_null().execute()?)
+}


### PR DESCRIPTION
This change updates native_function_returning_object and native_function_returning_scalar to translate crate::Error and rust panics into a corresponding Java exception.

https://github.com/duchess-rs/duchess/issues/173