### PR TITLE
Set the JNI Version to 1.6 on Android

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -15,7 +15,11 @@ use jni_sys::jvalue;
 
 use crate::{jvm::JavaObjectExt, Error, JavaObject, Local};
 
+// TODO: Allow users to set the JVM version
+#[cfg(not(target_os = "android"))]
 const VERSION: jni_sys::jint = jni_sys::JNI_VERSION_1_8;
+#[cfg(target_os = "android")]
+const VERSION: jni_sys::jint = jni_sys::JNI_VERSION_1_6;
 
 /// Get a [`JvmPtr`] to an already initialized JVM (if one exists).
 ///


### PR DESCRIPTION
Android does not support JNI Version 1.8, so we compile it with 1.6. All other targets use JNI Version 1.6.

In the future, users should be able to specify the JNI version, but that is not the highest priority here.