### PR TITLE
Fix `Option<T>` fields when used as method arguments as well as in `ToJava`

### DIFF
--- a/duchess-reflect/src/codegen.rs
+++ b/duchess-reflect/src/codegen.rs
@@ -1217,10 +1217,10 @@ impl ClassInfo {
                 NonRepeatingType::Ref(_) => {
                     quote_spanned!(self.span =>
                         let #input_name = self.#input_name.into_as_jref(jvm)?;
-                        // The error case here is when the input is `Option<T>` (this is the only path to produce a NullJref)
-                        // `.ok()` converts `Nullable` into `Option<T>`—later, this uses the `IntoJniValue` impl
-                        // for Option<&T>` which produces a null pointer.
-                        let #input_name = duchess::prelude::AsJRef::as_jref(&#input_name).ok();
+                        let #input_name = match duchess::prelude::AsJRef::as_jref(&#input_name) {
+                            Ok(v) => Some(v),
+                            Err(duchess::NullJRef) => None,
+                        };
                     )
                 }
             })

--- a/test-crates/duchess-java-tests/java/derives/OptionalFields.java
+++ b/test-crates/duchess-java-tests/java/derives/OptionalFields.java
@@ -1,0 +1,2 @@
+package derives;
+public record OptionalFields(String a, String b) {}

--- a/test-crates/duchess-java-tests/tests/rust-to-java/derive_options.rs
+++ b/test-crates/duchess-java-tests/tests/rust-to-java/derive_options.rs
@@ -1,0 +1,23 @@
+//@run
+use duchess::{java, prelude::*};
+
+duchess::java_package! {
+    package derives;
+    class derives.OptionalFields { * }
+}
+
+#[derive(duchess::ToJava)]
+#[java(derives.OptionalFields)]
+struct OptionalFields {
+    a: Option<String>,
+    b: String,
+}
+
+pub fn main() -> duchess::Result<()> {
+    let rust = OptionalFields {
+        a: None,
+        b: "hello".to_string(),
+    };
+    let java = rust.to_java().execute()?;
+    Ok(())
+}

--- a/test-crates/duchess-java-tests/tests/rust-to-java/passing_null_values.rs
+++ b/test-crates/duchess-java-tests/tests/rust-to-java/passing_null_values.rs
@@ -1,4 +1,4 @@
-//@check-pass
+//@run
 use duchess::prelude::*;
 
 duchess::java_package! {

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -31,11 +31,7 @@ fn to_java_and_back() {
         // nul byte
         "\u{0000}",
     ] {
-        let java: Java<java::lang::String> = example
-            .to_java()
-            .assert_not_null()
-            .execute()
-            .unwrap();
+        let java: Java<java::lang::String> = example.to_java().assert_not_null().execute().unwrap();
         let and_back: String = (&*java).execute().unwrap();
         assert_eq!(example, and_back);
     }


### PR DESCRIPTION
Prior to this codegen change, the test fails with the somewhat cryptic:
```

full stderr:
Error: attempted to deref a null Java object pointer

full stdout:
```

This occurs because when we convert `None` into a JRef, it becomes `Result<T, NullJRef>`. When the generated code calls `?` on that result, it bails out.

But, in this case we actually **want** to pass null. I updated it to use `.ok();` instead—this produces an `Option<T>` instead of a result, causing the later code to convert `None` into the JNI ref as intended.

Before:
```rust
                    let a0 = self.a0.into_as_jref(jvm)?;
                    let a0 = duchess::prelude::AsJRef::as_jref(&a0)?;
                    let a1 = self.a1.into_as_jref(jvm)?;
                    let a1 = duchess::prelude::AsJRef::as_jref(&a1)?;
```

After:
```rust
                    let a0 = self.a0.into_as_jref(jvm)?;
                    let a0 = duchess::prelude::AsJRef::as_jref(&a0).ok();
                    let a1 = self.a1.into_as_jref(jvm)?;
                    let a1 = duchess::prelude::AsJRef::as_jref(&a1).ok();
```

I beleive this change is correct because the only path of code that can actually produce a `NullJRef` is `impl TryJDeref` for `Option<T>`, which is exactly the case we want to handle.