### PR TITLE
Fix autobless

### DIFF
--- a/.github/workflows/autobless.yml
+++ b/.github/workflows/autobless.yml
@@ -39,7 +39,17 @@ jobs:
         git switch -c $BRANCH
         git push -u origin $BRANCH
     - name: Create Pull Request
-      run: gh pr create -B main --title 'Automatic bless' --body ''
+      run: |
+        BRANCH="bless-$(date -u +%Y-%m-%d)"
+        MAIN_SHA=$(git rev-parse main)
+        BRANCH_SHA=$(git rev-parse $BRANCH)
+
+        # Check if the commit hashes are different
+        if [ "$MAIN_SHA" != "$BRANCH_SHA" ]; then
+            gh pr create -B main --title 'Automatic bless' --body ''
+        else
+            echo "No changes between main and $BRANCH, skipping pull request creation."
+        fi
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DUCHESS_BLESS: 1


### PR DESCRIPTION
Duchess autobless [fails](https://github.com/duchess-rs/duchess/actions/runs/10313816006) to auto create create PR's when there are no changes.

We update autobless to check for change before creating a PR.

```
Run gh pr create -B main --title 'Automatic bless' --body ''
pull request create failed: GraphQL: No commits between main and bless-2024-08-0[9](https://github.com/duchess-rs/duchess/actions/runs/10313816006/job/28551205865#step:9:10) (createPullRequest)
```