### PR TITLE
pretty-close-to-build-rs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ TESTNAME=log_global_ref_and_chained_calls just test
 ```
 
 ### Debugging
-Duchess looks for the `DUCHESS_DEBUG` environment variable during proc-macro expansion. When this variable is set, if it is `true` or `1`, **all** generated code will be formatted and dumped to a directory. Clickable links are printed to stderr:
+Duchess looks for the `DUCHESS_DEBUG` environment variable during proc-macro expansion and `build.rs` execution. When this variable is set, if it is `true` or `1`, **all** generated code will be formatted and dumped to a directory. Additionally, this emits output from the buildscript as `warning` lines for cargo so they become visible.
+
+For proc macro expansion, clickable links are printed to stderr:
 
 For example:
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1.37"
 java-locator = { version = "0.1.3", optional = true }
 libloading = { version = "0.8.0", optional = true }
 derive-where = "1.2.1"
+serde = { version = "1.0.214", features = ["derive"] }
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ libloading = { version = "0.8.0", optional = true }
 derive-where = "1.2.1"
 serde = { version = "1.0.214", features = ["derive"] }
 
+[build-dependencies]
+duchess-build-rs = { path = "duchess-build-rs" }
+
 
 [features]
 default = ["dylibjvm"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    duchess_build_rs::DuchessBuildRs::new()
+        .with_src_path("src/".into())
+        .execute()
+        .unwrap();
+}

--- a/duchess-build-rs/Cargo.toml
+++ b/duchess-build-rs/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 
 [dependencies]
 anyhow = "1.0.86"
-duchess-reflect = { version = "0.3.0", path = "../duchess-reflect" }
+duchess-reflect = { version = "0.3.0", path = "../duchess-reflect", features = ["javap-reflection"] }
 lazy_static = "1.5.0"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"

--- a/duchess-build-rs/src/derive_java.rs
+++ b/duchess-build-rs/src/derive_java.rs
@@ -1,0 +1,62 @@
+use duchess_reflect::{
+    argument::MethodSelector,
+    parse::{Parse, Parser},
+    reflect::Reflect,
+};
+use proc_macro2::Span;
+use syn::{parse::ParseStream, Attribute};
+
+use crate::re;
+
+pub(crate) fn process_file(
+    rs_file: &crate::files::File,
+    reflector: &mut duchess_reflect::reflect::JavapReflector,
+) -> anyhow::Result<bool> {
+    let mut watch_file = false;
+    eprintln!("Looking for derive(java) in {:?}", rs_file.path);
+    for capture in re::java_derive().captures_iter(&rs_file.contents) {
+        eprintln!("Debug: found derive(java) in {:?}", rs_file.path);
+        let std::ops::Range { start, end: _ } = capture.get(0).unwrap().range();
+        let derive_java_attr: DeriveJavaAttr = match syn::parse_str(rs_file.rust_slice_from(start))
+        {
+            Ok(attr) => attr,
+            Err(e) => {
+                eprintln!("Error: failed to parse derive(java) attribute: {}", e);
+                return Ok(true);
+            }
+        };
+        reflector.reflect(
+            &derive_java_attr.method_selector.class_name(),
+            Span::call_site(),
+        )?;
+        watch_file = true;
+    }
+    Ok(watch_file)
+}
+
+#[derive(Debug)]
+struct DeriveJavaAttr {
+    method_selector: MethodSelector,
+}
+
+impl syn::parse::Parse for DeriveJavaAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attributes = input.call(Attribute::parse_outer)?;
+        for attr in attributes {
+            if !attr.path().is_ident("java") {
+                continue;
+            }
+            let derive_tokens = attr.meta.require_list()?.tokens.clone();
+            let mut parser: Parser = derive_tokens.into();
+            let method_selector = MethodSelector::parse(&mut parser)?.ok_or(syn::Error::new(
+                input.span(),
+                "expected a class in the attribute",
+            ))?;
+            return Ok(DeriveJavaAttr { method_selector });
+        }
+        Err(syn::Error::new(
+            input.span(),
+            "expected #[java(...)] attribute",
+        ))
+    }
+}

--- a/duchess-build-rs/src/files.rs
+++ b/duchess-build-rs/src/files.rs
@@ -7,7 +7,7 @@ pub(crate) struct File {
     pub(crate) contents: String,
 }
 
-pub fn rs_files(path: &Path) -> impl Iterator<Item = anyhow::Result<File>> {
+pub fn rs_files(path: impl AsRef<Path>) -> impl Iterator<Item = anyhow::Result<File>> {
     WalkDir::new(path)
         .into_iter()
         .filter_map(|entry| -> Option<anyhow::Result<File>> {
@@ -51,24 +51,41 @@ impl File {
     /// This is used when we are preprocessing and we find
     /// some kind of macro invocation. We want to grab all
     /// the text that may be part of it and pass it into `syn`.
+    // TODO: this should actually return an error, its basically never right to return the whole file
     pub fn rust_slice_from(&self, offset: usize) -> &str {
         let mut counter = 0;
         let terminator = self.contents[offset..].char_indices().find(|&(_, c)| {
             if c == '{' || c == '[' || c == '(' {
                 counter += 1;
             } else if c == '}' || c == ']' || c == ')' {
+                counter -= 1;
+
                 if counter == 0 {
                     return true;
                 }
-
-                counter -= 1;
             }
 
             false
         });
+        if terminator.is_none() {
+            eprintln!("rust slice ran to end of file {counter}");
+        }
         match terminator {
-            Some((i, _)) => &self.contents[offset..offset + i],
+            Some((i, _)) => &self.contents[offset..offset + i + 1],
             None => &self.contents[offset..],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_rust_slice() {
+        for file in super::rs_files("test-files") {
+            let file = file.unwrap();
+            for offset in file.contents.char_indices().map(|(i, _)| i) {
+                let _ = file.rust_slice_from(offset);
+            }
         }
     }
 }

--- a/duchess-build-rs/src/files.rs
+++ b/duchess-build-rs/src/files.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use walkdir::WalkDir;
 
+use crate::log;
+
 pub(crate) struct File {
     pub(crate) path: PathBuf,
     pub(crate) contents: String,
@@ -68,7 +70,7 @@ impl File {
             false
         });
         if terminator.is_none() {
-            eprintln!("rust slice ran to end of file {counter}");
+            log!("rust slice ran to end of file {counter}");
         }
         match terminator {
             Some((i, _)) => &self.contents[offset..offset + i + 1],

--- a/duchess-build-rs/src/impl_java_trait.rs
+++ b/duchess-build-rs/src/impl_java_trait.rs
@@ -5,7 +5,7 @@ use duchess_reflect::{
 use proc_macro2::{Span, TokenStream};
 use syn::spanned::Spanned;
 
-use crate::{files::File, java_compiler::JavaCompiler, shim_writer::ShimWriter};
+use crate::{files::File, java_compiler::JavaCompiler, log, shim_writer::ShimWriter};
 
 pub fn process_impl(compiler: &JavaCompiler, file: &File, offset: usize) -> anyhow::Result<()> {
     let the_impl: JavaInterfaceImpl = syn::parse_str(file.rust_slice_from(offset))?;
@@ -48,7 +48,7 @@ impl JavaInterfaceImpl {
 
         compiler.compile_to_rs_file(&java_file)?;
 
-        eprintln!("compiled to {}", java_file.rs_path.display());
+        log!("compiled to {}", java_file.rs_path.display());
 
         Ok(())
     }

--- a/duchess-build-rs/src/impl_java_trait.rs
+++ b/duchess-build-rs/src/impl_java_trait.rs
@@ -1,4 +1,7 @@
-use duchess_reflect::{class_info::ClassRef, reflect::Reflector};
+use duchess_reflect::{
+    class_info::ClassRef,
+    reflect::{JavapReflector, Reflect},
+};
 use proc_macro2::{Span, TokenStream};
 use syn::spanned::Spanned;
 
@@ -29,7 +32,7 @@ impl syn::parse::Parse for JavaInterfaceImpl {
 
 impl JavaInterfaceImpl {
     fn generate_shim(&self, compiler: &JavaCompiler) -> anyhow::Result<()> {
-        let reflector = Reflector::new(compiler.configuration());
+        let mut reflector = JavapReflector::new(compiler.configuration());
         let (java_interface_ref, java_interface_span) = self.java_interface()?;
         let java_interface_info =
             reflector.reflect(&java_interface_ref.name, java_interface_span)?;

--- a/duchess-build-rs/src/java_package_macro.rs
+++ b/duchess-build-rs/src/java_package_macro.rs
@@ -91,17 +91,15 @@ fn cache_all_classes(
 
 #[cfg(test)]
 mod test {
-    use crate::JavaCompiler;
-    use duchess_reflect::config::Configuration;
-    use tempfile::tempdir;
+    use duchess_reflect::{config::Configuration, reflect::JavapReflector};
 
     #[test]
     fn process_file() {
-        let compiler = &JavaCompiler::new(&Configuration::new(), None).unwrap();
+        let mut compiler = JavapReflector::new(&Configuration::new());
         let rs_file = crate::files::File {
             path: "test-files/java_package_1.rs".into(),
             contents: include_str!("../test-files/java_package_1.rs").to_string(),
         };
-        super::process_file(&rs_file, &compiler).unwrap();
+        super::process_file(&rs_file, &mut compiler).unwrap();
     }
 }

--- a/duchess-build-rs/src/java_package_macro.rs
+++ b/duchess-build-rs/src/java_package_macro.rs
@@ -1,14 +1,54 @@
 use anyhow::Context;
-use duchess_reflect::{argument::DuchessDeclaration, parse::Parser, reflect::Reflector};
-use proc_macro2::TokenStream;
+use duchess_reflect::{argument::DuchessDeclaration, parse::Parser, reflect::JavapReflector};
+use proc_macro2::{Span, TokenStream};
 
-use crate::{files::File, java_compiler::JavaCompiler};
+use crate::{files::File, java_package_macro, re};
 
-pub fn process_macro(compiler: &JavaCompiler, file: &File, offset: usize) -> anyhow::Result<()> {
-    let the_impl: JavaPackageMacro = syn::parse_str(file.rust_slice_from(offset))
-        .with_context(|| format!("{} failed to parse java_package macro", file.slug(offset),))?;
+pub fn process_file(rs_file: &File, reflector: &mut JavapReflector) -> anyhow::Result<bool> {
+    let mut watch_file = false;
+    for capture in re::java_package().captures_iter(&rs_file.contents) {
+        eprintln!("Debug: found java macro in {:?}", rs_file.path);
+        let std::ops::Range { start, end: _ } = capture.get(0).unwrap().range();
+        java_package_macro::process_macro(reflector, &rs_file, start)
+            .with_context(|| format!("failed to process macro {}", rs_file.slug(start)))?;
+        watch_file = true;
+    }
+    Ok(watch_file)
+}
 
-    the_impl.parse_contents(compiler)?;
+fn process_macro(reflector: &mut JavapReflector, file: &File, offset: usize) -> anyhow::Result<()> {
+    let the_impl: JavaPackageMacro = match syn::parse_str(file.rust_slice_from(offset))
+        .with_context(|| {
+            format!(
+                "{} failed to parse java_package macro as Rust code",
+                file.slug(offset),
+            )
+        })
+        .with_context(|| format!("full contents:\n>>>>{}<<<", file.rust_slice_from(offset)))
+    {
+        Ok(package) => package,
+        Err(e) => {
+            // we'll let rustc deal with this later
+            eprintln!(
+                "Warning: failed to parse java_package macro as Rust code, ignoring it. Error: {}",
+                e
+            );
+            return Ok(());
+        }
+    };
+
+    let contents = match the_impl.parse_contents() {
+        Ok(decl) => decl,
+        Err(e) => {
+            // we'll let rustc deal with this later
+            eprintln!(
+                "Warning: failed to parse java_package macro as Duchess code, ignoring it. Error: {}",
+                e
+            );
+            return Ok(());
+        }
+    };
+    cache_all_classes(contents, reflector).with_context(|| "failed to execute javap")?;
     Ok(())
 }
 
@@ -30,12 +70,38 @@ impl syn::parse::Parse for JavaPackageMacro {
 }
 
 impl JavaPackageMacro {
-    fn parse_contents(self, compiler: &JavaCompiler) -> anyhow::Result<()> {
+    fn parse_contents(self) -> anyhow::Result<DuchessDeclaration> {
         let input = self.invocation.mac.tokens;
-        let decl = Parser::from(input).parse::<DuchessDeclaration>()?;
-        let mut reflector = Reflector::new(compiler.configuration());
-        let root_map = decl.to_root_map(&mut reflector)?;
-        root_map.
-        Ok(())
+        Ok(Parser::from(input).parse::<DuchessDeclaration>()?)
+    }
+}
+
+fn cache_all_classes(
+    decl: DuchessDeclaration,
+    reflector: &mut JavapReflector,
+) -> anyhow::Result<()> {
+    let _root_map = decl.to_root_map(reflector)?;
+    for class in _root_map.class_names() {
+        // forcibly reflect every class
+        use duchess_reflect::reflect::Reflect;
+        reflector.reflect(&class, Span::call_site())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::JavaCompiler;
+    use duchess_reflect::config::Configuration;
+    use tempfile::tempdir;
+
+    #[test]
+    fn process_file() {
+        let compiler = &JavaCompiler::new(&Configuration::new(), None).unwrap();
+        let rs_file = crate::files::File {
+            path: "test-files/java_package_1.rs".into(),
+            contents: include_str!("../test-files/java_package_1.rs").to_string(),
+        };
+        super::process_file(&rs_file, &compiler).unwrap();
     }
 }

--- a/duchess-build-rs/src/java_package_macro.rs
+++ b/duchess-build-rs/src/java_package_macro.rs
@@ -34,8 +34,8 @@ impl JavaPackageMacro {
         let input = self.invocation.mac.tokens;
         let decl = Parser::from(input).parse::<DuchessDeclaration>()?;
         let mut reflector = Reflector::new(compiler.configuration());
-        let _root_map = decl.to_root_map(&mut reflector)?;
-        // FIXME: next step is to dump the data from the reflector into OUT_DIR
+        let root_map = decl.to_root_map(&mut reflector)?;
+        root_map.
         Ok(())
     }
 }

--- a/duchess-build-rs/src/lib.rs
+++ b/duchess-build-rs/src/lib.rs
@@ -9,6 +9,7 @@ mod files;
 mod impl_java_trait;
 mod java_compiler;
 mod java_package_macro;
+mod derive_java;
 mod re;
 mod shim_writer;
 
@@ -101,6 +102,7 @@ impl DuchessBuildRs {
 
             eprintln!("looking for java macros in {:?}", rs_file.path);
             watch_file |= java_package_macro::process_file(&rs_file, &mut reflector)?;
+            watch_file |= derive_java::process_file(&rs_file, &mut reflector)?;
 
             for capture in re::impl_java_interface().captures_iter(&rs_file.contents) {
                 let std::ops::Range { start, end: _ } = capture.get(0).unwrap().range();

--- a/duchess-build-rs/src/log.rs
+++ b/duchess-build-rs/src/log.rs
@@ -1,0 +1,12 @@
+#[macro_export]
+macro_rules! log {
+    ($($tokens: tt)*) => {
+        if std::env::var("DUCHESS_DEBUG").is_ok() {
+            // print logging at warn level so it's easy to see (without intentionally failing the build)
+            println!("cargo:warning={}", format!($($tokens)*))
+        } else {
+            // otherwise `eprintln` (this will be visible if the build script panics)
+            eprintln!("{}", format!($($tokens)*))
+        }
+    }
+}

--- a/duchess-build-rs/src/re.rs
+++ b/duchess-build-rs/src/re.rs
@@ -14,6 +14,8 @@ declare_regex!(impl_java_interface() = r"#\[duchess::impl_java_interface\]");
 
 declare_regex!(java_package() = r"(?m)^\s*(duchess|duchess_macro)::java_package! *\{");
 
+declare_regex!(java_derive() = r"#\[java\(([\w.]+)(?:::\w+)?\)\]");
+
 #[cfg(test)]
 mod test {
     #[test]
@@ -33,5 +35,11 @@ mod test {
             public final native void notify();
             public final native void notifyAll();"#;
         assert!(super::java_package().is_match(java_file));
+    }
+
+    #[test]
+    fn test_java_derive() {
+        assert!(super::java_derive().is_match("#[java(java.lang.Long::decode)]"));
+        assert!(super::java_derive().is_match("#[java(java.lang.Throwable)]"));
     }
 }

--- a/duchess-build-rs/src/re.rs
+++ b/duchess-build-rs/src/re.rs
@@ -12,4 +12,26 @@ macro_rules! declare_regex {
 
 declare_regex!(impl_java_interface() = r"#\[duchess::impl_java_interface\]");
 
-declare_regex!(java_package() = r"duchess::java_package! *\{");
+declare_regex!(java_package() = r"(?m)^\s*(duchess|duchess_macro)::java_package! *\{");
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_java_package_regex() {
+        assert!(super::java_package().is_match(r#"       duchess_macro::java_package! { "#));
+        let java_file = r#"
+    NB. in doctests, the current crate is already available as duchess.
+
+    duchess_macro::java_package! {
+        package java.lang;
+
+        public class java.lang.Object {
+            public java.lang.Object();
+            public native int hashCode();
+            public boolean equals(java.lang.Object);
+            public java.lang.String toString();
+            public final native void notify();
+            public final native void notifyAll();"#;
+        assert!(super::java_package().is_match(java_file));
+    }
+}

--- a/duchess-build-rs/test-files/java_package_1.rs
+++ b/duchess-build-rs/test-files/java_package_1.rs
@@ -1,0 +1,24 @@
+//@run
+use duchess::prelude::*;
+
+// Generate our own version of java.util.Date that
+// explicitly does NOT include the `toString` method,
+// so that we have to get it by upcasting to Object.
+mod our_java {
+    duchess::java_package! {
+        package java.util;
+
+        public class java.util.Date {
+            public java.util.Date();
+        }
+    }
+    pub use java::*;
+}
+
+pub fn main() -> duchess::Result<()> {
+    let date = our_java::util::Date::new().execute()?;
+    let s: String = date.to_string().assert_not_null().execute()?;
+    //                   ^^^^^^^^^^^ this is defined on `java.lang.Object`
+    println!("Today's date is {s}");
+    Ok(())
+}

--- a/duchess-reflect/Cargo.toml
+++ b/duchess-reflect/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 documentation.workspace = true
 description = "Internal component of duchess crate"
 
+[features]
+javap-reflection = []
+
 [dependencies]
 anyhow = "1.0.70"
 lalrpop-util = { version = "0.19.9", features = ["lexer"] }
@@ -16,6 +19,7 @@ proc-macro2 = "1.0.56"
 quote = "1.0.26"
 rust-format = { version = "0.3.4", features = ["token_stream"] }
 serde = { version = "1.0.214", features = ["derive", "rc"] }
+serde_json = "1.0.132"
 str_inflector = "0.12.0"
 syn = "2.0.15"
 tempfile = "3.8.1"

--- a/duchess-reflect/Cargo.toml
+++ b/duchess-reflect/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = "1.4.0"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 rust-format = { version = "0.3.4", features = ["token_stream"] }
+serde = { version = "1.0.214", features = ["derive", "rc"] }
 str_inflector = "0.12.0"
 syn = "2.0.15"
 tempfile = "3.8.1"

--- a/duchess-reflect/src/argument.rs
+++ b/duchess-reflect/src/argument.rs
@@ -27,6 +27,7 @@ impl Parse for DuchessDeclaration {
 /// such method), a class + method name, or a little mini class declaration
 /// that includes the full details (which accommodates the case where it is
 /// overloaded).
+#[derive(Debug)]
 pub enum MethodSelector {
     /// User wrote `foo.bar.Baz`
     ClassName(JavaPath),

--- a/duchess-reflect/src/check.rs
+++ b/duchess-reflect/src/check.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 
 use crate::{
     class_info::{ClassInfo, ClassRef, Constructor, Flags, Method, RefType, RootMap, Type},
-    reflect::{JavapClassInfo, Reflector},
+    reflect::{JavapClassInfo, PrecomputedReflector},
 };
 
 impl RootMap {
-    pub fn check(&self, reflector: &mut Reflector) -> syn::Result<()> {
+    pub fn check(&self, reflector: &PrecomputedReflector) -> syn::Result<()> {
         let mut errors = vec![];
 
         for class_name in &self.class_names() {
@@ -28,7 +28,7 @@ impl ClassInfo {
     fn check(
         &self,
         root_map: &RootMap,
-        reflector: &mut Reflector,
+        reflector: &PrecomputedReflector,
         push_error: &mut dyn FnMut(syn::Error),
     ) -> syn::Result<()> {
         let info = reflector.reflect(&self.name, self.span)?;

--- a/duchess-reflect/src/class_info.rs
+++ b/duchess-reflect/src/class_info.rs
@@ -723,10 +723,29 @@ impl std::fmt::Display for Id {
 }
 
 /// A dotted identifier
-#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug, Deserialize, Serialize)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug)]
 pub struct DotId {
     /// Dotted components. Invariant: len >= 1.
     ids: Vec<Id>,
+}
+
+impl Serialize for DotId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.with_sep("."))
+    }
+}
+
+impl<'de> Deserialize<'de> for DotId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(DotId::parse(&s))
+    }
 }
 
 impl From<Id> for DotId {

--- a/duchess-reflect/src/class_info.rs
+++ b/duchess-reflect/src/class_info.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use inflector::Inflector;
 use proc_macro2::{Delimiter, Ident, Span, TokenStream, TokenTree};
 use quote::quote_spanned;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     parse::{Parse, TextAccum},
@@ -130,16 +131,15 @@ impl Parse for ClassDecl {
 #[derive(Clone, Debug)]
 pub struct ReflectedClassInfo {
     pub span: Span,
-    #[allow(dead_code)] // FIXME: replace with `#[expect]` once that stabilizes
     pub flags: Flags,
     pub name: DotId,
     pub kind: ClassKind,
 }
 
+/// ClassInfo that was parsed from a hand written declaration
 #[derive(Clone, Debug)]
 pub struct ClassInfo {
     pub span: Span,
-    #[allow(dead_code)] // FIXME: replace with `#[expect]` once that stabilizes
     pub flags: Flags,
     pub name: DotId,
     pub kind: ClassKind,
@@ -238,7 +238,7 @@ impl ClassInfo {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Deserialize, Serialize)]
 pub struct Generic {
     pub id: Id,
     pub extends: Vec<ClassRef>,
@@ -263,13 +263,13 @@ impl std::fmt::Display for Generic {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug, Deserialize, Serialize)]
 pub enum ClassKind {
     Class,
     Interface,
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Flags {
     pub privacy: Privacy,
     pub is_final: bool,
@@ -298,7 +298,7 @@ impl Flags {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum Privacy {
     Public,
     Protected,
@@ -327,7 +327,7 @@ pub enum MemberFunction {
     Method(Method),
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct Constructor {
     pub flags: Flags,
     pub generics: Vec<Generic>,
@@ -361,14 +361,14 @@ impl Constructor {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct Field {
     pub flags: Flags,
     pub name: Id,
     pub ty: Type,
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct Method {
     pub flags: Flags,
     pub name: Id,
@@ -447,7 +447,7 @@ impl std::fmt::Display for MethodSig {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Deserialize, Serialize)]
 pub struct ClassRef {
     pub name: DotId,
     pub generics: Vec<RefType>,
@@ -467,7 +467,7 @@ impl std::fmt::Display for ClassRef {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub enum Type {
     Ref(RefType),
     Scalar(ScalarType),
@@ -585,7 +585,7 @@ impl NonRepeatingType {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub enum RefType {
     Class(ClassRef),
     Array(Arc<Type>),
@@ -608,7 +608,7 @@ impl std::fmt::Display for RefType {
     }
 }
 
-#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub enum ScalarType {
     Int,
     Long,
@@ -664,7 +664,7 @@ impl ScalarType {
 }
 
 /// A single identifier
-#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug, Serialize, Deserialize)]
 pub struct Id {
     pub data: String,
 }
@@ -723,7 +723,7 @@ impl std::fmt::Display for Id {
 }
 
 /// A dotted identifier
-#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug)]
+#[derive(Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Debug, Deserialize, Serialize)]
 pub struct DotId {
     /// Dotted components. Invariant: len >= 1.
     ids: Vec<Id>,

--- a/duchess-reflect/src/config.rs
+++ b/duchess-reflect/src/config.rs
@@ -3,12 +3,12 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Configuration {
     data: Arc<Data>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Data {
     classpath: String,
     java_home: Option<PathBuf>,

--- a/duchess-reflect/src/reflect.rs
+++ b/duchess-reflect/src/reflect.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, collections::BTreeMap, process::Command, sync::Arc};
 
 use proc_macro2::Span;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     argument::{DuchessDeclaration, Ident, JavaPackage, MethodSelector},
@@ -238,7 +239,7 @@ impl Reflector {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JavapClassInfo {
     #[allow(dead_code)] // FIXME: replace with `#[expect]` once that stabilizes
     pub flags: Flags,

--- a/duchess-reflect/src/reflect.rs
+++ b/duchess-reflect/src/reflect.rs
@@ -226,7 +226,7 @@ impl PrecomputedReflector {
         self.classes.get(class_name).map(Arc::clone).ok_or_else(|| {
             syn::Error::new(
                 span,
-                format!("no reflected value for {class_name} this is a bug"),
+                format!("no reflected value for `{class_name}` this is a bug"),
             )
         })
     }

--- a/duchess-reflect/src/reflect/javap.rs
+++ b/duchess-reflect/src/reflect/javap.rs
@@ -1,0 +1,106 @@
+use std::{collections::BTreeMap, path::Path, process::Command, sync::Arc};
+
+use anyhow::{bail, Context};
+use proc_macro2::Span;
+
+use crate::{
+    class_info::{ClassInfo, DotId},
+    config::Configuration,
+};
+
+use super::{reflection_cache, JavapClassInfo, Reflect};
+
+/// Reflector that uses JavaP to perform reflection
+#[derive(Debug)]
+pub struct JavapReflector {
+    configuration: Configuration,
+    classes: BTreeMap<DotId, Arc<JavapClassInfo>>,
+}
+
+impl Reflect for JavapReflector {
+    fn reflect(&mut self, dot_id: &DotId, span: Span) -> syn::Result<Arc<JavapClassInfo>> {
+        JavapReflector::reflect_and_cache(self, dot_id, span)
+    }
+}
+
+impl JavapReflector {
+    pub fn new(configuration: &Configuration) -> Self {
+        Self {
+            configuration: configuration.clone(),
+            classes: BTreeMap::new(),
+        }
+    }
+
+    fn serialize(&self) -> String {
+        serde_json::to_string_pretty(&self.classes).expect("failed to serialize JSON")
+    }
+
+    pub fn dump_to(&self, out_dir: impl AsRef<Path>) -> anyhow::Result<()> {
+        let path = reflection_cache(out_dir);
+        let json = self.serialize();
+        std::fs::write(&path, json)
+            .with_context(|| format!("writing reflection cache data to {:?}", path))?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.classes.len()
+    }
+
+    fn reflect_via_javap(&self, class_name: &DotId, span: Span) -> anyhow::Result<JavapClassInfo> {
+        let mut command = Command::new(self.configuration.bin_path("javap"));
+
+        if let Some(classpath) = self.configuration.classpath() {
+            command.arg("-cp").arg(classpath);
+        }
+
+        command.arg("-p").arg(format!("{}", class_name));
+
+        let output_or_err = command.output();
+
+        let output = match output_or_err {
+            Ok(o) => o,
+            Err(err) => {
+                bail!("failed to execute `{command:?}`: {err}")
+            }
+        };
+
+        if !output.status.success() {
+            bail!(
+                "unsuccessful execution of `{command:?}` (exit status: {}): {}",
+                output.status,
+                String::from_utf8(output.stderr).unwrap_or(String::from("error"))
+            );
+        }
+
+        let s = match String::from_utf8(output.stdout) {
+            Ok(o) => o,
+            Err(err) => {
+                bail!("failed to parse output of `{command:?}` as utf-8: {err}")
+            }
+        };
+
+        let ci = ClassInfo::parse(&s, span)?;
+        Ok(JavapClassInfo::from(ci))
+    }
+
+    fn reflect_and_cache(
+        &mut self,
+        class_name: &DotId,
+        span: Span,
+    ) -> syn::Result<Arc<JavapClassInfo>> {
+        if let Some(ci) = self.classes.get(class_name) {
+            return Ok(Arc::clone(ci));
+        }
+
+        let ci = self
+            .reflect_via_javap(class_name, span)
+            .map_err(|err| syn::Error::new(span, format!("{}", err)))?;
+
+        let ci = Arc::new(ci);
+
+        self.classes.insert(class_name.clone(), Arc::clone(&ci));
+
+        Ok(ci)
+    }
+}

--- a/justfile
+++ b/justfile
@@ -17,7 +17,10 @@ integration-test-jni-1_6:
 integration-test-jni-1_8:
     (cd test-crates && cargo test --features jni_1_8)
 
-test: unit-test integration-test
+build-rs-tests:
+  (cd duchess-build-rs && cargo test)
+
+test: build-rs-tests unit-test integration-test
 
 test-jni-1_8: unit-test-jni-1_8 integration-test-jni-1_8
 

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use duchess_reflect::{
-    class_info::ClassInfoAccessors, config::Configuration, reflect::JavapClassInfo,
+    class_info::ClassInfoAccessors,
+    reflect::{JavapClassInfo, PrecomputedReflector},
 };
 use proc_macro2::{Span, TokenStream};
 use quote::quote_spanned;
@@ -15,7 +16,6 @@ use crate::{
     argument::{JavaPath, MethodSelector},
     class_info::{ClassRef, Type},
     parse::{Parse, Parser},
-    reflect::Reflector,
     signature::Signature,
     upcasts::Upcasts,
 };
@@ -23,7 +23,7 @@ use crate::{
 pub fn derive_to_rust(s: synstructure::Structure) -> proc_macro2::TokenStream {
     let mut driver = Driver {
         input: &s,
-        reflector: &mut Reflector::new(&Configuration::default()),
+        reflector: &PrecomputedReflector::new().unwrap(),
     };
     match driver.try_derive_to_rust() {
         Ok(t) => {
@@ -37,7 +37,7 @@ pub fn derive_to_rust(s: synstructure::Structure) -> proc_macro2::TokenStream {
 pub fn derive_to_java(s: synstructure::Structure) -> proc_macro2::TokenStream {
     let mut driver = Driver {
         input: &s,
-        reflector: &mut Reflector::new(&Configuration::default()),
+        reflector: &PrecomputedReflector::new().unwrap(),
     };
     match driver.try_derive_to_java() {
         Ok(t) => {
@@ -50,7 +50,7 @@ pub fn derive_to_java(s: synstructure::Structure) -> proc_macro2::TokenStream {
 
 struct Driver<'a> {
     input: &'a synstructure::Structure<'a>,
-    reflector: &'a mut Reflector,
+    reflector: &'a PrecomputedReflector,
 }
 
 impl Driver<'_> {

--- a/src/java.rs
+++ b/src/java.rs
@@ -235,7 +235,7 @@ mod auto {
             public java.lang.Object clone();
         }
 
-        public class java.util.Date { // implements java.io.Serializable, java.lang.Cloneable, java.lang.Comparable<java.util.Date> {
+        public class java.util.Date {
             public java.util.Date();
             //   public java.util.Date(long);
             //   public java.util.Date(int, int, int);
@@ -385,16 +385,16 @@ mod auto {
             public static final java.lang.management.MemoryType HEAP;
             public static final java.lang.management.MemoryType NON_HEAP;
             private final java.lang.String description;
-            private static final java.lang.management.MemoryType[] $VALUES;
-            public static java.lang.management.MemoryType[] values();
+            //private static final java.lang.management.MemoryType[] $VALUES;
+            //public static java.lang.management.MemoryType[] values();
             public static java.lang.management.MemoryType valueOf(java.lang.String);
             private java.lang.management.MemoryType(java.lang.String);
             public java.lang.String toString();
-            private static java.lang.management.MemoryType[] $values();
+            //private static java.lang.management.MemoryType[] $values();
             static {};
-          }
-    }
-}
+        } // end of memory type
+    } // end of java package
+} // end of mod auto
 
 pub use auto::java::*;
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -9,7 +9,8 @@ pub struct JavaFunction {
     pub(crate) class_fn: ClassFn,
 }
 
-pub type ClassFn = for<'jvm> fn(jvm: &mut Jvm<'jvm>) -> crate::LocalResult<'jvm, Local<'jvm, Class>>;
+pub type ClassFn =
+    for<'jvm> fn(jvm: &mut Jvm<'jvm>) -> crate::LocalResult<'jvm, Local<'jvm, Class>>;
 
 impl JavaFunction {
     /// Create a new `JavaFunction` value with an appropriate name, signature, and function pointer.

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -21,10 +21,7 @@ pub enum State {
     Detached,
 }
 
-fn attached_or(
-    jvm: JvmPtr,
-    f: impl FnOnce() -> Result<AttachGuard>,
-) -> Result<AttachGuard> {
+fn attached_or(jvm: JvmPtr, f: impl FnOnce() -> Result<AttachGuard>) -> Result<AttachGuard> {
     STATE.with(|state| match state.replace(State::InUse) {
         State::AttachedPermanently(env) => Ok(AttachGuard {
             jvm,

--- a/test-crates/viper/Cargo.toml
+++ b/test-crates/viper/Cargo.toml
@@ -8,6 +8,7 @@ duchess = { path = "../.." }
 
 [build-dependencies]
 ureq = "2.1"
+duchess-build-rs = { path = "../../duchess-build-rs" }
 
 [features]
 jni_1_6 = ["duchess/jni_1_6"]

--- a/test-crates/viper/build.rs
+++ b/test-crates/viper/build.rs
@@ -1,5 +1,7 @@
 use std::{env, fs, io, path};
 
+use duchess_build_rs::Configuration;
+
 static JAR_URL: &str =
     "https://github.com/viperproject/viperserver/releases/download/v.23.01-release/viperserver.jar";
 
@@ -12,6 +14,8 @@ fn main() {
     let mut jar_file = fs::File::create(jar_path.clone()).unwrap();
     io::copy(&mut jar_data.into_reader(), &mut jar_file).unwrap();
 
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-env=CLASSPATH={}", jar_path.display());
+    duchess_build_rs::DuchessBuildRs::new()
+        .with_configuration(Configuration::new().push_classpath(jar_path.display()))
+        .execute()
+        .unwrap();
 }

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -3,11 +3,8 @@ use duchess::{java, Java, JvmOp, ToJava};
 macro_rules! test_array {
     ($type: ty, $item: expr) => {
         for test_array in [vec![$item], vec![], vec![$item, $item, $item]] {
-            let java: Java<java::Array<$type>> = test_array
-                .to_java()
-                .assert_not_null()
-                .execute()
-                .unwrap();
+            let java: Java<java::Array<$type>> =
+                test_array.to_java().assert_not_null().execute().unwrap();
             let and_back: Vec<_> = (&*java).execute().unwrap();
             assert_eq!(test_array, and_back);
         }


### PR DESCRIPTION
Moves javap into build.rs. Error handling works pretty well. There is one missing piece to also capture `#[java...]` derives
since those must also be reflected in build.rs.