### PR TITLE
Add array tests to the java-to-rust ui tests

### DIFF
--- a/test-crates/duchess-java-tests/tests/java-to-rust/java/java_to_rust_arrays/JavaArrayTests.java
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/java/java_to_rust_arrays/JavaArrayTests.java
@@ -1,0 +1,22 @@
+//@check-pass
+package java_to_rust_arrays;
+
+import java.util.Arrays;
+
+public class JavaArrayTests {
+    public static native long combine_bytes(byte[] bytes);
+    public static native byte[] break_bytes(long num);
+
+    public static void main(String[] args) {
+        System.loadLibrary("native_fn_arrays");
+        byte[] bytes = {1, 1, 1, 1, 1, 1, 1, 1};
+        long combo = JavaArrayTests.combine_bytes(bytes);
+        if (combo != 72340172838076673L) {
+            throw new RuntimeException("expected: 72340172838076673 got: " + combo);
+        }
+        byte[] broken_combo = JavaArrayTests.break_bytes(combo);
+        if (!Arrays.equals(broken_combo, bytes)) {
+            throw new RuntimeException("expected: " + Arrays.toString(bytes) + " got: " + Arrays.toString(broken_combo));
+        }
+    }
+}

--- a/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/native_fn_arrays.rs
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/native_fn_arrays.rs
@@ -1,0 +1,29 @@
+//@check-pass
+
+use duchess::prelude::*;
+use duchess::{java, Java, JvmOp, ToJava};
+
+duchess::java_package! {
+    package java_to_rust_arrays;
+
+    public class JavaArrayTests {
+        public static native long combine_bytes(byte[]);
+        public static native byte[] break_bytes(long);
+    }
+}
+
+#[duchess::java_function(java_to_rust_arrays.JavaArrayTests::combine_bytes)]
+fn combine_bytes(bytes: &duchess::java::Array<i8>) -> i64 {
+    let signed_bytes: &[i8] = &*bytes.execute::<Vec<i8>>().unwrap();
+    let unsigned_bytes = signed_bytes.iter().map(|x| *x as u8).collect::<Vec<u8>>();
+    return i64::from_le_bytes(unsigned_bytes.try_into().unwrap());
+}
+
+#[duchess::java_function(java_to_rust_arrays.JavaArrayTests::break_bytes)]
+fn break_bytes(num: i64) -> duchess::Result<Java<java::Array<i8>>> {
+    let unsigned_bytes = num.to_le_bytes();
+    let signed_bytes = unsigned_bytes.iter().map(|x| *x as i8).collect::<Vec<i8>>();
+    let java_array: Java<java::Array<i8>> = signed_bytes.to_java().execute()?.unwrap();
+
+    return Ok(java_array);
+}


### PR DESCRIPTION
I found it difficult to make use of arrays with JNI functions. I'm adding these ui tests to give an example to others.
