### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ logger
 
 Check out the...
 
-* The [examples](https://github.com/duchess-rs/duchess/tree/main/test-crates/duchess-java-tests/tests/ui/examples)
+* The [examples](https://github.com/duchess-rs/duchess/tree/main/test-crates/duchess-java-tests/tests)
 * The [tutorials](https://duchess-rs.github.io/duchess/tutorials.html) chapter
 
 ## Curious to get involved?


### PR DESCRIPTION
Looks like this was broken between 0.2.1 and 0.3.0.