### PR TITLE
Update java_function to allow Options with &mut.

### DIFF
--- a/src/java.rs
+++ b/src/java.rs
@@ -402,3 +402,4 @@ pub use auto::java::*;
 // Should it go somewhere outside of the JDK core classes?
 pub use crate::array::JavaArray as Array;
 pub use crate::array::JavaArrayExt as ArrayExt;
+pub use crate::array::JavaArrayModificationExt as ArrayModificationExt;

--- a/test-crates/duchess-java-tests/tests/java-to-rust/java/java_to_rust_arrays/JavaArrayTests.java
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/java/java_to_rust_arrays/JavaArrayTests.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 public class JavaArrayTests {
     public static native long combine_bytes(byte[] bytes);
     public static native byte[] break_bytes(long num);
+    public static native long fillWithOnes(byte[] arr, int len);
+    public static native long fillWithTrue(boolean[] arr, int len);
 
     public static void main(String[] args) {
         System.loadLibrary("native_fn_arrays");
@@ -17,6 +19,31 @@ public class JavaArrayTests {
         byte[] broken_combo = JavaArrayTests.break_bytes(combo);
         if (!Arrays.equals(broken_combo, bytes)) {
             throw new RuntimeException("expected: " + Arrays.toString(bytes) + " got: " + Arrays.toString(broken_combo));
+        }
+
+        byte[] arr = new byte[5];
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i] != 0) {
+                throw new RuntimeException("Array not initialized to 0 at index " + i);
+            }
+        }
+        fillWithOnes(arr, arr.length);
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i] != 1) {
+                throw new RuntimeException("Rust did not set all elements to 1 at index " + i);
+            }
+        }
+        boolean[] b_arr = new boolean[5];
+        for (int i = 0; i < b_arr.length; i++) {
+            if (b_arr[i] != false) {
+                throw new RuntimeException("Array not initialized to false at index " + i);
+            }
+        }
+        fillWithTrue(b_arr, arr.length);
+        for (int i = 0; i < b_arr.length; i++) {
+            if (b_arr[i] != true) {
+                throw new RuntimeException("Rust did not set all elements to true at index " + i);
+            }
         }
     }
 }

--- a/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/native_fn_arrays.rs
+++ b/test-crates/duchess-java-tests/tests/java-to-rust/rust-libraries/native_fn_arrays.rs
@@ -1,6 +1,6 @@
 //@check-pass
 
-use duchess::prelude::*;
+use duchess::java::ArrayModificationExt;
 use duchess::{java, Java, JvmOp, ToJava};
 
 duchess::java_package! {
@@ -9,6 +9,8 @@ duchess::java_package! {
     public class JavaArrayTests {
         public static native long combine_bytes(byte[]);
         public static native byte[] break_bytes(long);
+        public static native long fillWithOnes(byte[], int);
+        public static native long fillWithTrue(boolean[], int);
     }
 }
 
@@ -26,4 +28,18 @@ fn break_bytes(num: i64) -> duchess::Result<Java<java::Array<i8>>> {
     let java_array: Java<java::Array<i8>> = signed_bytes.to_java().execute()?.unwrap();
 
     return Ok(java_array);
+}
+
+#[duchess::java_function(java_to_rust_arrays.JavaArrayTests::fillWithOnes)]
+fn fill_with_ones(arr: Option<&mut duchess::java::Array<i8>>, len: i32) -> i64 {
+    let region: Vec<i8> = vec![1; len as usize];
+    arr.unwrap().set_array_region(0, &region).execute();
+    0
+}
+
+#[duchess::java_function(java_to_rust_arrays.JavaArrayTests::fillWithTrue)]
+fn fill_with_true(arr: Option<&mut duchess::java::Array<bool>>, len: i32) -> i64 {
+    let region: Vec<bool> = vec![true; len as usize];
+    arr.unwrap().set_array_region(0, &region).execute();
+    0
 }


### PR DESCRIPTION
Also update primitive arrays to support a new function `set_array_region`. `set_array_region` calls Set<Primitive>ArrayRegion. This allows for mutability of java arrays in place without needing to transform them into rust arrays first