### PR TITLE
Support generic exceptions, Rust keywords in Java identifiers

### DIFF
--- a/duchess-reflect/Cargo.toml
+++ b/duchess-reflect/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro2 = "1.0.56"
 quote = "1.0.26"
 rust-format = { version = "0.3.4", features = ["token_stream"] }
 str_inflector = "0.12.0"
-syn = "2.0.15"
+syn = { version = "2.0.15", features = ["parsing"] }
 tempfile = "3.8.1"
 
 [build-dependencies]

--- a/duchess-reflect/src/class_info.rs
+++ b/duchess-reflect/src/class_info.rs
@@ -622,7 +622,11 @@ impl Id {
 
     pub fn to_ident(&self, span: Span) -> Ident {
         let data = self.data.replace("$", "__");
-        Ident::new(&data, span)
+        // A legal Java identifier may be an illegal Rust identifier, in which case we'd 
+        // need to use raw syntax. 
+        let mut ident = syn::parse_str(data.as_str()).unwrap_or_else(|_| Ident::new_raw(&data, span));
+        ident.set_span(span);
+        ident
     }
 
     pub fn to_snake_case(&self) -> Self {

--- a/duchess-reflect/src/class_info/javap_parser.lalrpop
+++ b/duchess-reflect/src/class_info/javap_parser.lalrpop
@@ -161,8 +161,13 @@ Privacy: Privacy = {
 
 Throws: Vec<ClassRef> = {
     () => vec![],
-    "throws" <Comma1<ClassRef>>,
-}
+    "throws" <Comma1<ThrowsType>>,
+};
+
+ThrowsType: ClassRef = {
+    ClassRef,
+    <Id> => ClassRef { name: <>.into(), generics: vec![] },
+};
 
 #[inline]
 ReturnType: Option<Type> = {

--- a/duchess-reflect/src/codegen.rs
+++ b/duchess-reflect/src/codegen.rs
@@ -943,11 +943,18 @@ impl ClassInfo {
             .chain(&input_names)
             .collect();
 
+       
+        let method_struct_generics_with_defaults: Vec<_> = method_struct_generics
+            .iter()
+            .map(|g| quote_spanned!(self.span => #g = java::lang::Object))
+            .collect();
+
         // For each method `m` in the Java type, we create a struct (named `m`)
-        // that will implement the `JvmOp`.
+        // that will implement the `JvmOp`. We need to provide defaults for all
+        // generic parameters to enable type inference at the instantiation site.
         let method_struct = quote_spanned!(self.span =>
             pub struct #rust_method_type_name<
-                #(#method_struct_generics,)*
+                #(#method_struct_generics_with_defaults,)*
             > {
                 #(#input_names : #input_names,)*
                 phantom: ::core::marker::PhantomData<(
@@ -1036,6 +1043,17 @@ impl ClassInfo {
             )
         });
 
+        // For the constructor call, we need explicit type parameters: class generics
+        // and method generics by name, but wildcards for input parameter types
+        // (which can be inferred from the arguments).
+        let method_struct_explicit_types: Vec<_> = java_class_generics
+            .iter()
+            .chain(rust_method_generics.iter())
+            .map(|g| quote_spanned!(self.span => #g))
+            .chain(input_names.iter().map(|_| quote_spanned!(self.span => _)))
+            .collect();
+
+
         let inherent_method = quote_spanned!(self.span =>
             pub fn #rust_method_name<#(#rust_method_generics),*>(
                 #(#input_names: impl #input_traits),*
@@ -1049,7 +1067,7 @@ impl ClassInfo {
 
                 #deref_impl
 
-                #rust_method_type_name {
+                #rust_method_type_name::<#(#method_struct_explicit_types),*> {
                     #(#input_names: #input_names.into_op(),)*
                     phantom: ::core::default::Default::default(),
                 }

--- a/test-crates/duchess-java-tests/java/exceptions/GenericExceptionThrower.java
+++ b/test-crates/duchess-java-tests/java/exceptions/GenericExceptionThrower.java
@@ -1,0 +1,20 @@
+package exceptions;
+
+public class GenericExceptionThrower<E extends java.lang.Exception> {
+    private E e_;
+    public GenericExceptionThrower(E e) {
+        e_ = e;
+    }
+
+    public void throwsGenericAndSimple() throws E, RuntimeException {
+        throw e_;
+    }
+    
+    public static <T, E2 extends java.lang.Exception> void throwsGenericException(T _t, E2 e) throws E2 {
+        throw e;
+    }
+
+    public static RuntimeException returnsException() {
+        return new RuntimeException("test exception");
+    }
+}

--- a/test-crates/duchess-java-tests/java/keyword/impl/WithKeywordImpl.java
+++ b/test-crates/duchess-java-tests/java/keyword/impl/WithKeywordImpl.java
@@ -1,0 +1,7 @@
+package keyword.impl;
+
+public class WithKeywordImpl {
+    public static String getMessage() {
+        return "impl keyword test";
+    }
+}

--- a/test-crates/duchess-java-tests/tests/rust-to-java/keyword_impl.rs
+++ b/test-crates/duchess-java-tests/tests/rust-to-java/keyword_impl.rs
@@ -1,0 +1,12 @@
+//@run
+use duchess::prelude::*;
+
+duchess::java_package! {
+    package keyword.impl;
+    class keyword.impl.WithKeywordImpl { * }
+}
+fn main() -> duchess::Result<()> {
+    let message: String = keyword::r#impl::WithKeywordImpl::get_message().assert_not_null().execute()?;
+    assert_eq!(message, "impl keyword test");
+    Ok(())
+}

--- a/test-crates/duchess-java-tests/tests/rust-to-java/throws_generic_exceptions.rs
+++ b/test-crates/duchess-java-tests/tests/rust-to-java/throws_generic_exceptions.rs
@@ -1,0 +1,29 @@
+//@run
+
+use duchess::prelude::*;
+use java::lang::RuntimeException;
+
+duchess::java_package! {
+    package exceptions;
+    
+    public class GenericExceptionThrower<E extends java.lang.Exception> {
+        public exceptions.GenericExceptionThrower(E);
+        public void throwsGenericAndSimple() throws E, java.lang.RuntimeException;
+        public static <T, E2 extends java.lang.Exception> void throwsGenericException(T, E2) throws E2;
+        public static java.lang.RuntimeException returnsException();
+    }
+}
+
+
+fn main() -> duchess::Result<()> {
+    let e = exceptions::GenericExceptionThrower::<RuntimeException>::returns_exception().execute().unwrap().unwrap();
+    let e = exceptions::GenericExceptionThrower::<RuntimeException>::throws_generic_exception::<java::lang::Object, RuntimeException>("test", &e).execute().unwrap_err();
+    let duchess::Error::Thrown(e) = e else {
+        panic!("Did not throw exception as expected");
+    };
+    let runtime = e.try_downcast::<RuntimeException>().execute().unwrap().unwrap();
+    let thrower = exceptions::GenericExceptionThrower::<RuntimeException>::new(&runtime);
+    let e2 = thrower.throws_generic_and_simple().execute().unwrap_err();
+    Ok(())
+}
+


### PR DESCRIPTION
Fixes two issues around duchess not accepting certain Java code:

1. When the Java identifier has a reserved Rust keyword, use Rust literal syntax. For example, `impl` in Java code should become `r#impl` in the generated Rust. Fixing this required enabling syn's `parsing` to detect Rust keywords, I can find an alternative if this is problematic for some reason.
2. Support throwing generic exceptions, as `throws E` is perfectly legal in Java code. 