### PR TITLE
Fix double free when object is upcasted

### DIFF
--- a/src/ref_.rs
+++ b/src/ref_.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Deref, ptr::NonNull};
+use std::{marker::PhantomData, mem::ManuallyDrop, ops::Deref, ptr::NonNull};
 
 use crate::jvm::JavaObjectExt;
 use crate::thread;
@@ -180,9 +180,15 @@ impl<'a, R: JavaObject> Local<'a, R> {
         R: Upcast<S>,
         S: JavaObject + 'a,
     {
-        // SAFETY: From the Upcast trait contract, we know R is also an instance of S
-        let upcast = unsafe { Local::<S>::from_raw(self.env, self.obj) };
-        upcast
+        // From the Upcast trait contract, we know R is also an instance of S, so the invariant of _marker must be satisfied.
+        // We also need to ensure the Drop of Self does not run as that would free the underlying JVM local ref, 
+        // causing a double-free when the upcasted Drop runs and frees the same local ref again.  
+        let self_ = ManuallyDrop::new(self);
+        Local {
+            env: self_.env,
+            obj: self_.obj,
+            _marker: PhantomData
+        }
     }
 }
 
@@ -203,8 +209,13 @@ impl<R: JavaObject> Java<R> {
         R: Upcast<S>,
         S: JavaObject + 'static,
     {
-        // SAFETY: From the Upcast trait contract, we know R is also an instance of S
-        let upcast = unsafe { Java::<S>::from_raw(self.obj) };
-        upcast
+        // From the Upcast trait contract, we know R is also an instance of S, so the invariant of _marker must be satisfied.
+        // We also need to ensure the Drop of Self does not run as that would free the underlying JVM global ref, 
+        // causing a double-free when the upcasted Drop runs and frees the same global ref again.  
+        let self_ = ManuallyDrop::new(self);
+        Java {
+            obj: self_.obj,
+            _marker: PhantomData,
+        }
     }
 }

--- a/test-crates/duchess-java-tests/tests/rust-to-java/upcast_no_double_free.rs
+++ b/test-crates/duchess-java-tests/tests/rust-to-java/upcast_no_double_free.rs
@@ -1,0 +1,10 @@
+//@run
+
+use duchess::prelude::*;
+
+pub fn main() -> duchess::Result<()> {
+    let java_string: Java<java::lang::String> = "test".to_java::<java::lang::String>().execute()?.unwrap();
+    let java_object: Java<java::lang::Object> = java_string.upcast::<java::lang::Object>();
+
+    Ok(())
+}


### PR DESCRIPTION
The [threat model states it should be 1:1 between JNI local/global and Duchess Java/Local](https://github.com/duchess-rs/duchess/blob/main/book/src/threat_model.md#11-correspondence-between-jni-globallocal-references-and-globallocal): when an object is upcasted, this is violated, as both the upcast and original would point to the same JNI ref, and as such, would both free on drop. The added `upcast_no_double_free.rs` also demonstrates this, as it reliably segfaults without the fix. As a bit of a sitenote, as far as I can tell, it's not actually possible to cause this with Local in practice as Duchess itself doesn't upcast a Local and user code can't really get it's hands on one.
 
I went with what seemed like the simplest fix, which is to prevent dropping the subject of the upcast. IMO, it still feels like a bit of a footgun that the caller of `Local::from_raw`/`Java::from_raw` is responsible for making sure the destructor of the original object doesn't run, especially since `JavaObjectExt::from_raw` doesn't have this same invariant. Maybe the `ObjectPtr` should be pinned and only unpinned during upcast? In any case, I think this approach is probably good enough to fix the immediate issue. 


