### PR TITLE
Add JDK 25 to CI and fix Class.isInterface/isArray/isPrimitive incompatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,8 @@ jobs:
       run: ./mdbook test book
 
   # JDK 25 changed Class.isInterface(), isArray(), isPrimitive() from native
-  # to ordinary methods. This causes duchess-reflect's native-method check to
-  # fail. This job exists to demonstrate the incompatibility.
+  # to ordinary methods backed by HotSpot intrinsics. This job verifies duchess
+  # works correctly on JDK 25+.
   build-jdk25:
     strategy:
       matrix:
@@ -53,7 +53,6 @@ jobs:
         jni-version: ['1_8']
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,33 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: ./mdbook test book
 
+  # JDK 25 changed Class.isInterface(), isArray(), isPrimitive() from native
+  # to ordinary methods. This causes duchess-reflect's native-method check to
+  # fail. This job exists to demonstrate the incompatibility.
+  build-jdk25:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        jni-version: ['1_8']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+    - name: Show Java version
+      run: java -version
+    - name: Show javap output for Class native methods
+      run: javap -p java.lang.Class | grep -E "(isInterface|isArray|isPrimitive)"
+    - name: Build
+      run: cargo build --verbose
+    - name: Test crates, jni_${{ matrix.jni-version }}
+      run: cargo test --all-targets --verbose --features jni_${{ matrix.jni-version }}
+
   coverage:
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin'
         java-version: '25'
@@ -68,6 +68,8 @@ jobs:
       run: cargo build --verbose
     - name: Test crates, jni_${{ matrix.jni-version }}
       run: cargo test --all-targets --verbose --features jni_${{ matrix.jni-version }}
+    - name: Test client crates, jni_${{ matrix.jni-version }}
+      run: cargo test --all-targets --verbose --manifest-path=test-crates/Cargo.toml --features jni_${{ matrix.jni-version }}
 
   coverage:
     runs-on: 'ubuntu-latest'

--- a/duchess-reflect/src/check.rs
+++ b/duchess-reflect/src/check.rs
@@ -199,13 +199,17 @@ impl ClassInfo {
             ));
         }
 
-        // JDK 25 demoted java.lang.Class.isInterface(), isArray(), and isPrimitive()
-        // from `native` methods to ordinary methods backed by HotSpot intrinsics.
-        // Pre-existing duchess-reflect declarations in src/java.rs marked them as
-        // native, which is correct for JDK 21 and earlier but no longer matches
-        // what `javap` reports on JDK 25+. We accept native-in-Rust + non-native-in-Java
-        // to support both. The reverse direction (non-native-in-Rust + native-in-Java)
-        // is still treated as an error since that indicates a real binding mismatch.
+        // The is_native flag is only used for compile-time validation and does not
+        // affect codegen — duchess invokes all methods via JNI CallXxxMethodA regardless
+        // of native status.
+        //
+        // We allow native-in-Rust + non-native-in-Java because JDK 25 demoted
+        // Class.isInterface(), isArray(), and isPrimitive() from native to ordinary
+        // methods, and we need to support both JDK ≤21 and JDK 25+.
+        //
+        // The reverse (non-native-in-Rust + native-in-Java) is still an error because
+        // it means the user may need to provide a Rust implementation via
+        // #[duchess::java_function] and hasn't marked the method as native.
 
         if !flags.is_native && reflected_flags.is_native {
             push_error(format!(

--- a/duchess-reflect/src/check.rs
+++ b/duchess-reflect/src/check.rs
@@ -199,11 +199,13 @@ impl ClassInfo {
             ));
         }
 
-        if flags.is_native && !reflected_flags.is_native {
-            push_error(format!(
-                "member declared as native but it is not native in Java",
-            ));
-        }
+        // JDK 25 demoted java.lang.Class.isInterface(), isArray(), and isPrimitive()
+        // from `native` methods to ordinary methods backed by HotSpot intrinsics.
+        // Pre-existing duchess-reflect declarations in src/java.rs marked them as
+        // native, which is correct for JDK 21 and earlier but no longer matches
+        // what `javap` reports on JDK 25+. We accept native-in-Rust + non-native-in-Java
+        // to support both. The reverse direction (non-native-in-Rust + native-in-Java)
+        // is still treated as an error since that indicates a real binding mismatch.
 
         if !flags.is_native && reflected_flags.is_native {
             push_error(format!(


### PR DESCRIPTION
## Summary

This PR adds JDK 25 to the CI matrix and fixes the incompatibility that causes duchess-reflect to fail on JDK 25.

## Problem

JDK 25 demoted `java.lang.Class.isInterface()`, `isArray()`, and `isPrimitive()` from `native` methods to ordinary methods backed by HotSpot intrinsics. The duchess-reflect `check.rs` validation previously treated "declared as native in Rust but not native in Java" as a hard error, which breaks on JDK 25+ where `javap` no longer reports these methods as native.

Errors on JDK 25 before this fix:
```
java.lang.Class::isInterface: member declared as native but it is not native in Java
java.lang.Class::isArray: member declared as native but it is not native in Java
java.lang.Class::isPrimitive: member declared as native but it is not native in Java
```

## Fix

This PR implements the simplest fix: remove the "native-in-Rust + non-native-in-Java" error arm from `compare_flags()` in `duchess-reflect/src/check.rs`. This allows duchess declarations that mark methods as `native` (correct for JDK ≤21) to coexist with JDK 25+ where those methods are no longer native.

The reverse check ("non-native-in-Rust + native-in-Java") is preserved, since that still indicates a real binding mismatch where the Rust side is missing a native declaration that Java requires.

## Changes

1. **`duchess-reflect/src/check.rs`**: Remove the `flags.is_native && !reflected_flags.is_native` error arm. Add a comment explaining the JDK 25 intrinsification.
2. **`.github/workflows/rust.yml`**: Remove `continue-on-error: true` from the JDK 25 job (it is now expected to pass). Update the job comment to reflect that this verifies duchess works on JDK 25+.

## Testing

- JDK 17/21: existing CI jobs continue to pass (control — nothing broken)
- JDK 25: new CI job now passes with the fix applied
- `cargo build` and `cargo check --workspace` pass locally