### PR TITLE
fix: support JDK 25 by relaxing native-method check (backport to 0.3.x)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,32 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: ./mdbook test book
 
+  # JDK 25 changed Class.isInterface(), isArray(), isPrimitive() from native
+  # to ordinary methods backed by HotSpot intrinsics. This job verifies duchess
+  # works correctly on JDK 25+.
+  build-jdk25:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        jni-version: ['1_8']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+    - name: Show Java version
+      run: java -version
+    - name: Show javap output for Class native methods
+      run: javap -p java.lang.Class | grep -E "(isInterface|isArray|isPrimitive)"
+    - name: Build
+      run: cargo build --verbose
+    - name: Test crates, jni_${{ matrix.jni-version }}
+      run: cargo test --all-targets --verbose --features jni_${{ matrix.jni-version }}
+
   coverage:
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin'
         java-version: '25'
@@ -68,6 +68,8 @@ jobs:
       run: cargo build --verbose
     - name: Test crates, jni_${{ matrix.jni-version }}
       run: cargo test --all-targets --verbose --features jni_${{ matrix.jni-version }}
+    - name: Test client crates, jni_${{ matrix.jni-version }}
+      run: cargo test --all-targets --verbose --manifest-path=test-crates/Cargo.toml --features jni_${{ matrix.jni-version }}
 
   coverage:
     runs-on: 'ubuntu-latest'

--- a/duchess-reflect/src/check.rs
+++ b/duchess-reflect/src/check.rs
@@ -197,11 +197,13 @@ impl ClassInfo {
             ));
         }
 
-        if flags.is_native && !reflected_flags.is_native {
-            push_error(format!(
-                "member declared as native but it is not native in Java",
-            ));
-        }
+        // JDK 25 demoted java.lang.Class.isInterface(), isArray(), and isPrimitive()
+        // from `native` methods to ordinary methods backed by HotSpot intrinsics.
+        // Pre-existing duchess-reflect declarations in src/java.rs marked them as
+        // native, which is correct for JDK 21 and earlier but no longer matches
+        // what `javap` reports on JDK 25+. We accept native-in-Rust + non-native-in-Java
+        // to support both. The reverse direction (non-native-in-Rust + native-in-Java)
+        // is still treated as an error since that indicates a real binding mismatch.
 
         if !flags.is_native && reflected_flags.is_native {
             push_error(format!(

--- a/duchess-reflect/src/check.rs
+++ b/duchess-reflect/src/check.rs
@@ -197,13 +197,17 @@ impl ClassInfo {
             ));
         }
 
-        // JDK 25 demoted java.lang.Class.isInterface(), isArray(), and isPrimitive()
-        // from `native` methods to ordinary methods backed by HotSpot intrinsics.
-        // Pre-existing duchess-reflect declarations in src/java.rs marked them as
-        // native, which is correct for JDK 21 and earlier but no longer matches
-        // what `javap` reports on JDK 25+. We accept native-in-Rust + non-native-in-Java
-        // to support both. The reverse direction (non-native-in-Rust + native-in-Java)
-        // is still treated as an error since that indicates a real binding mismatch.
+        // The is_native flag is only used for compile-time validation and does not
+        // affect codegen — duchess invokes all methods via JNI CallXxxMethodA regardless
+        // of native status.
+        //
+        // We allow native-in-Rust + non-native-in-Java because JDK 25 demoted
+        // Class.isInterface(), isArray(), and isPrimitive() from native to ordinary
+        // methods, and we need to support both JDK ≤21 and JDK 25+.
+        //
+        // The reverse (non-native-in-Rust + native-in-Java) is still an error because
+        // it means the user may need to provide a Rust implementation via
+        // #[duchess::java_function] and hasn't marked the method as native.
 
         if !flags.is_native && reflected_flags.is_native {
             push_error(format!(


### PR DESCRIPTION
Cherry-pick of the JDK 25 fix onto release-0.3.x.

JDK 25 demoted `java.lang.Class.isInterface()`, `isArray()`, and `isPrimitive()` from native methods to ordinary methods. This caused duchess-reflect's native-method check to error on JDK 25+.

This removes the 'declared as native but not native in Java' error arm while preserving the reverse check. Also adds a JDK 25 CI job.

Backport of #208.