### PR TITLE
fix: replace deprecated TempDir::into_path() with TempDir::keep()

### DIFF
--- a/duchess-reflect/Cargo.toml
+++ b/duchess-reflect/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.214", features = ["derive", "rc"] }
 serde_json = "1.0.132"
 str_inflector = "0.12.0"
 syn = "2.0.15"
-tempfile = "3.8.1"
+tempfile = "3.15.0"
 
 [build-dependencies]
 lalrpop = "0.19.9"

--- a/duchess-reflect/src/lib.rs
+++ b/duchess-reflect/src/lib.rs
@@ -16,7 +16,7 @@ pub mod upcasts;
 lazy_static::lazy_static! {
     pub static ref DEBUG_DIR: PathBuf = {
         let tmp_dir = tempfile::TempDir::new().expect("failed to create temp directory");
-        tmp_dir.into_path()
+        tmp_dir.keep()
     };
 }
 


### PR DESCRIPTION
We were seeing deprecation warnings on an old tempfile API:

```
warning: use of deprecated method `tempfile::TempDir::into_path`: use TempDir::keep()
    --> patched-crates/duchess-reflect-0.3.2/src/lib.rs:18:17:18:26
```

Bumping tempfile from `3.8.1` -> `3.15.0` for when `keep()` was added, and cutting over usage.