### PR TITLE
chore: release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.3 (May 28th, 2026)
+**Bug fixes**:
+* Support JDK 25 by relaxing native-method check in duchess-reflect (#209)
+* Replace deprecated `TempDir::into_path()` with `TempDir::keep()`, bump tempfile to 3.15.0 (#210)
+
 # 0.3.2 (February 5th, 2026)
 **New features**:
 * Support generic exceptions (#205)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["duchess-reflect"]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/duchess-rs/duchess"
 homepage = "https://duchess-rs.github.io/duchess/"

--- a/duchess-reflect/Cargo.toml
+++ b/duchess-reflect/Cargo.toml
@@ -17,7 +17,7 @@ quote = "1.0.26"
 rust-format = { version = "0.3.4", features = ["token_stream"] }
 str_inflector = "0.12.0"
 syn = { version = "2.0.15", features = ["parsing"] }
-tempfile = "3.8.1"
+tempfile = "3.15.0"
 
 [build-dependencies]
 lalrpop = "0.19.9"

--- a/duchess-reflect/src/lib.rs
+++ b/duchess-reflect/src/lib.rs
@@ -15,7 +15,7 @@ pub mod upcasts;
 lazy_static::lazy_static! {
     static ref DEBUG_DIR: PathBuf = {
         let tmp_dir = tempfile::TempDir::new().expect("failed to create temp directory");
-        tmp_dir.into_path()
+        tmp_dir.keep()
     };
 }
 


### PR DESCRIPTION
- backporting #210 to 0.3.x
- 0.3.x release