### PR TITLE
chore: release duchess-reflect@0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.4](https://github.com/duchess-rs/duchess/compare/duchess-v0.3.3...duchess-v0.3.4) - 2026-06-08
+
+### Other
+
+- updated the following local packages: duchess-macro
 # 0.3.3 (May 28th, 2026)
 **Bug fixes**:
 * Support JDK 25 by relaxing native-method check in duchess-reflect (#209)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 
 [dependencies]
 derive_more = "0.99.17"
-duchess-macro = { path = "macro", version = "0.3.0" }
+duchess-macro = { path = "macro", version = "0.3.3" }
 jni-sys = "0.3.0"
 cesu8 = "1.1.0"
 once_cell = "1.17.1"

--- a/duchess-reflect/CHANGELOG.md
+++ b/duchess-reflect/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.3](https://github.com/duchess-rs/duchess/compare/duchess-reflect-v0.3.2...duchess-reflect-v0.3.3) - 2026-06-08
+
+### Fixed
+
+- support JDK 25 by relaxing native-method check (backport to 0.3.x) ([#209](https://github.com/duchess-rs/duchess/pull/209))
+
+### Other
+
+- release 0.3.3 ([#211](https://github.com/duchess-rs/duchess/pull/211))

--- a/macro/CHANGELOG.md
+++ b/macro/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.4](https://github.com/duchess-rs/duchess/compare/duchess-macro-v0.3.3...duchess-macro-v0.3.4) - 2026-06-08
+
+### Other
+
+- updated the following local packages: duchess-reflect

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = "1.17.1"
 synstructure = "0.13.0"
 syn = "2.0.15"
 derive-where = "1.2.1"
-duchess-reflect = { version = "0.3.0", path = "../duchess-reflect" }
+duchess-reflect = { version = "0.3.3", path = "../duchess-reflect" }
 
 [build-dependencies]
 lalrpop = "0.19.9"


### PR DESCRIPTION
#211 only released `duchess` crate but missed `duchess-reflect`, notably #210 .

AIUI we don't need to bump any consumers of `duchess-reflect` since cargo semver will anyway resolve to the newer patch version. `release-plz update` did bump the path dependencies, which I guess is harmless (probably we should cut to cargo workspace dep statement).